### PR TITLE
chore: remove unnecessary FC-47 items from the MVP

### DIFF
--- a/Dashboard/Dashboard/Presentation/Elements/CourseCardView.swift
+++ b/Dashboard/Dashboard/Presentation/Elements/CourseCardView.swift
@@ -63,17 +63,19 @@ struct CourseCardView: View {
                 }
                 courseTitle
             }
-            if !hasAccess {
-                ZStack(alignment: .center) {
-                    Circle()
-                        .foregroundStyle(Theme.Colors.primaryHeaderColor)
-                        .opacity(0.7)
-                        .frame(width: 24, height: 24)
-                    CoreAssets.lockIcon.swiftUIImage
-                        .foregroundStyle(Theme.Colors.textPrimary)
-                }
-                .padding(8)
-            }
+            
+            // Commenting this for MVP, LEARNER-10102
+//            if !hasAccess {
+//                ZStack(alignment: .center) {
+//                    Circle()
+//                        .foregroundStyle(Theme.Colors.primaryHeaderColor)
+//                        .opacity(0.7)
+//                        .frame(width: 24, height: 24)
+//                    CoreAssets.lockIcon.swiftUIImage
+//                        .foregroundStyle(Theme.Colors.textPrimary)
+//                }
+//                .padding(8)
+//            }
         }
         .background(Theme.Colors.courseCardBackground)
         .cornerRadius(8)

--- a/Dashboard/Dashboard/Presentation/Elements/CourseCardView.swift
+++ b/Dashboard/Dashboard/Presentation/Elements/CourseCardView.swift
@@ -65,18 +65,21 @@ struct CourseCardView: View {
             }
             
             // Commenting this for MVP, LEARNER-10102
-//            if !hasAccess {
-//                ZStack(alignment: .center) {
-//                    Circle()
-//                        .foregroundStyle(Theme.Colors.primaryHeaderColor)
-//                        .opacity(0.7)
-//                        .frame(width: 24, height: 24)
-//                    CoreAssets.lockIcon.swiftUIImage
-//                        .foregroundStyle(Theme.Colors.textPrimary)
-//                }
-//                .padding(8)
-//            }
+            /*
+            if !hasAccess {
+                ZStack(alignment: .center) {
+                    Circle()
+                        .foregroundStyle(Theme.Colors.primaryHeaderColor)
+                        .opacity(0.7)
+                        .frame(width: 24, height: 24)
+                    CoreAssets.lockIcon.swiftUIImage
+                        .foregroundStyle(Theme.Colors.textPrimary)
+                }
+                .padding(8)
+            }
+            */
         }
+             
         .background(Theme.Colors.courseCardBackground)
         .cornerRadius(8)
         .shadow(color: Theme.Colors.courseCardShadow, radius: 6, x: 2, y: 2)

--- a/OpenEdX/Managers/PushNotificationsManager/Providers/FCMProvider.swift
+++ b/OpenEdX/Managers/PushNotificationsManager/Providers/FCMProvider.swift
@@ -51,8 +51,9 @@ class FCMProvider: NSObject, PushNotificationsProvider, MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         storage.pushToken = fcmToken
         
-        guard let fcmToken, storage.user != nil else { return }
-        sendFCMToken(fcmToken)
+        // Commenting this for MVP, LEARNER-10102
+//        guard let fcmToken, storage.user != nil else { return }
+//        sendFCMToken(fcmToken)
     }
     
     private func sendFCMToken(_ token: String) {

--- a/Profile/Profile/Presentation/Settings/SettingsView.swift
+++ b/Profile/Profile/Presentation/Settings/SettingsView.swift
@@ -71,7 +71,8 @@ public struct SettingsView: View {
                                     viewModel.serverConfig.iapConfig.restoreEnabled {
                                     restorePurchases
                                 }
-                                datesAndCalendar
+                                // Commenting this for MVP, LEARNER-10102
+//                                datesAndCalendar
                                 ProfileSupportInfoView(viewModel: viewModel)
                                 logOutButton
                             }


### PR DESCRIPTION
The following items need to be removed as they are not necessary for our MVP launch and seem half-baked items from FC47 changes. 


1. Lock icon on course cards - we are not sure about the current logic and all the cases involved for showing the lock icon on course cards hence we have decided to remove this feature from the MVP and look into it closely post-mvp and give it more thought. 
2. Notification-related API implementation `/api/mobile/v4/notifications/create-token/`
3. Calendar sync settings - We also need to remove the Calendar Sync settings added in the settings screen under video download settings. Our calendar sync functionality does not work like this.
