### PR TITLE
chore: make IAP dependent on server config

### DIFF
--- a/Core/Core/Data/Model/Data_PrimaryEnrollment.swift
+++ b/Core/Core/Data/Model/Data_PrimaryEnrollment.swift
@@ -12,17 +12,25 @@ public extension DataLayer {
         public let userTimezone: String?
         public let enrollments: Enrollments?
         public let primary: ActiveEnrollment?
+        public let configs: ServerConfigs?
         
         enum CodingKeys: String, CodingKey {
             case userTimezone = "user_timezone"
             case enrollments
             case primary
+            case configs
         }
         
-        public init(userTimezone: String?, enrollments: Enrollments?, primary: ActiveEnrollment?) {
+        public init(
+            userTimezone: String?,
+            enrollments: Enrollments?,
+            primary: ActiveEnrollment?,
+            configs: ServerConfigs?
+        ) {
             self.userTimezone = userTimezone
             self.enrollments = enrollments
             self.primary = primary
+            self.configs = configs
         }
     }
     
@@ -205,16 +213,16 @@ public extension DataLayer {
 
 public extension DataLayer.PrimaryEnrollment {
     
-    func domain(baseURL: String) -> PrimaryEnrollment {
+    func domain(baseURL: String) -> (PrimaryEnrollment, DataLayer.ServerConfigs?) {
         let primaryCourse = createPrimaryCourse(from: self.primary, baseURL: baseURL)
         let courses = createCourseItems(from: self.enrollments, baseURL: baseURL)
         
-        return PrimaryEnrollment(
+        return (PrimaryEnrollment(
             primaryCourse: primaryCourse,
             courses: courses,
             totalPages: enrollments?.numPages ?? 1,
             count: enrollments?.count ?? 1
-        )
+        ), configs)
     }
     
     private func createPrimaryCourse(from primary: DataLayer.ActiveEnrollment?, baseURL: String) -> PrimaryCourse? {

--- a/Core/Core/View/Base/CourseCellView.swift
+++ b/Core/Core/View/Base/CourseCellView.swift
@@ -36,7 +36,8 @@ public struct CourseCellView: View {
         type: CellType,
         index: Int,
         cellsCount: Int,
-        upgradeAction: (() -> Void)? = nil
+        upgradeAction: (() -> Void)? = nil,
+        serverConfig: ServerConfigProtocol? = nil
     ) {
         self.model = model
         self.type = type
@@ -47,7 +48,7 @@ public struct CourseCellView: View {
         self.courseOrg =  model.org
         self.index = Double(index) + 1
         self.cellsCount = cellsCount
-        self.isUpgradeable = model.isUpgradeable
+        self.isUpgradeable = model.isUpgradeable && serverConfig?.iapConfig.enabled ?? false
         self.upgradeAction = upgradeAction
     }
     

--- a/Course/Course/Presentation/Container/CourseContainerView.swift
+++ b/Course/Course/Presentation/Container/CourseContainerView.swift
@@ -392,7 +392,8 @@ struct CourseScreensView_Previews: PreviewProvider {
                 enrollmentStart: nil,
                 enrollmentEnd: nil,
                 lastVisitedBlockID: nil,
-                coreAnalytics: CoreAnalyticsMock()
+                coreAnalytics: CoreAnalyticsMock(),
+                serverConfig: ServerConfigProtocolMock()
             ),
             courseDatesViewModel: CourseDatesViewModel(
                 interactor: CourseInteractor.mock,

--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -107,6 +107,7 @@ public class CourseContainerViewModel: BaseCourseViewModel {
     let coreAnalytics: CoreAnalytics
     private(set) var storage: CourseStorage
     private var courseID: String?
+    let serverConfig: ServerConfigProtocol
     
     public init(
         interactor: CourseInteractorProtocol,
@@ -124,7 +125,8 @@ public class CourseContainerViewModel: BaseCourseViewModel {
         enrollmentEnd: Date?,
         lastVisitedBlockID: String?,
         coreAnalytics: CoreAnalytics,
-        selection: CourseTab = CourseTab.course
+        selection: CourseTab = CourseTab.course,
+        serverConfig: ServerConfigProtocol
     ) {
         self.interactor = interactor
         self.authInteractor = authInteractor
@@ -143,7 +145,8 @@ public class CourseContainerViewModel: BaseCourseViewModel {
         self.lastVisitedBlockID = lastVisitedBlockID
         self.coreAnalytics = coreAnalytics
         self.selection = selection.rawValue
-
+        self.serverConfig = serverConfig
+        
         super.init(manager: manager)
         addObservers()
     }
@@ -230,7 +233,10 @@ public class CourseContainerViewModel: BaseCourseViewModel {
             await setDownloadsStates(courseStructure: courseStructure)
             self.courseStructure = courseStructure
             let type = type(for: courseStructure?.coursewareAccessDetails?.coursewareAccess)
-            shouldShowUpgradeButton = type == nil && courseStructure?.isUpgradeable ?? false
+            shouldShowUpgradeButton = type == nil 
+            && courseStructure?.isUpgradeable ?? false
+            && serverConfig.iapConfig.enabled
+            
             updateMenuBarVisibility()
 
             if isInternetAvaliable {

--- a/Course/Course/Presentation/Outline/CourseOutlineView.swift
+++ b/Course/Course/Presentation/Outline/CourseOutlineView.swift
@@ -332,7 +332,8 @@ struct CourseOutlineView_Previews: PreviewProvider {
             enrollmentStart: Date(),
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         Task {
             await withTaskGroup(of: Void.self) { group in

--- a/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
+++ b/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
@@ -381,7 +381,8 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
             enrollmentStart: Date(),
             enrollmentEnd: nil, 
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         Task {
             await withTaskGroup(of: Void.self) { group in

--- a/Course/CourseTests/Presentation/Container/CourseContainerViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Container/CourseContainerViewModelTests.swift
@@ -41,7 +41,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         let block = CourseBlock(
@@ -158,7 +159,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         let courseStructure = CourseStructure(
@@ -223,7 +225,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         let noInternetError = AFError.sessionInvalidated(error: URLError(.notConnectedToInternet))
@@ -267,7 +270,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         Given(interactor, .getCourseBlocks(courseID: "123",
@@ -308,7 +312,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         Given(interactor, .getCourseBlocks(courseID: "123",
@@ -349,7 +354,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         viewModel.trackSelectedTab(selection: .course, courseId: "1", courseName: "name")
@@ -490,7 +496,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         viewModel.courseStructure = courseStructure
         await viewModel.setDownloadsStates(courseStructure: courseStructure)
@@ -620,7 +627,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         viewModel.courseStructure = courseStructure
         await viewModel.setDownloadsStates(courseStructure: courseStructure)
@@ -750,7 +758,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         viewModel.courseStructure = courseStructure
         await viewModel.setDownloadsStates(courseStructure: courseStructure)
@@ -881,7 +890,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         viewModel.courseStructure = courseStructure
         await viewModel.setDownloadsStates(courseStructure: courseStructure)
@@ -1020,7 +1030,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         viewModel.courseStructure = courseStructure
         await viewModel.setDownloadsStates(courseStructure: courseStructure)
@@ -1159,7 +1170,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         viewModel.courseStructure = courseStructure
         await viewModel.setDownloadsStates(courseStructure: courseStructure)
@@ -1319,7 +1331,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             enrollmentStart: nil,
             enrollmentEnd: nil,
             lastVisitedBlockID: nil,
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         viewModel.courseStructure = courseStructure
         await viewModel.setDownloadsStates(courseStructure: courseStructure)

--- a/Dashboard/Dashboard/Data/DashboardRepository.swift
+++ b/Dashboard/Dashboard/Data/DashboardRepository.swift
@@ -66,8 +66,12 @@ public class DashboardRepository: DashboardRepositoryProtocol {
         )
             .mapResponse(DataLayer.PrimaryEnrollment.self)
             .domain(baseURL: config.baseURL.absoluteString)
-        persistence.savePrimaryEnrollment(enrollments: result)
-        return result
+        persistence.savePrimaryEnrollment(enrollments: result.0)
+        persistence.saveServerConfig(configs: result.1)
+        
+        serverConfig.initialize(serverConfig: result.1?.config)
+        
+        return result.0
     }
     
     public func getPrimaryEnrollmentOffline() async throws -> PrimaryEnrollment {
@@ -84,7 +88,7 @@ public class DashboardRepository: DashboardRepositoryProtocol {
         )
             .mapResponse(DataLayer.PrimaryEnrollment.self)
             .domain(baseURL: config.baseURL.absoluteString)
-        return result
+        return result.0
     }
 }
 

--- a/Dashboard/Dashboard/Presentation/ListDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/ListDashboardView.swift
@@ -75,7 +75,8 @@ public struct ListDashboardView: View {
                                                         lmsPrice: course.lmsPrice ?? .zero
                                                     )
                                                 }
-                                            }
+                                            },
+                                            serverConfig: viewModel.serverConfig
                                         )
                                         .padding(.horizontal, 20)
                                         .listRowBackground(Color.clear)
@@ -178,7 +179,8 @@ struct ListDashboardView_Previews: PreviewProvider {
             connectivity: Connectivity(),
             analytics: DashboardAnalyticsMock(),
             upgradehandler: CourseUpgradeHandlerProtocolMock(),
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         let router = DashboardRouterMock()
         

--- a/Dashboard/Dashboard/Presentation/ListDashboardViewModel.swift
+++ b/Dashboard/Dashboard/Presentation/ListDashboardViewModel.swift
@@ -35,17 +35,21 @@ public class ListDashboardViewModel: ObservableObject {
     private let coreAnalytics: CoreAnalytics
     private var onCourseEnrolledCancellable: AnyCancellable?
     private var refreshEnrollmentsCancellable: AnyCancellable?
+    let serverConfig: ServerConfigProtocol
     
     public init(interactor: DashboardInteractorProtocol,
                 connectivity: ConnectivityProtocol,
                 analytics: DashboardAnalytics,
                 upgradehandler: CourseUpgradeHandlerProtocol,
-                coreAnalytics: CoreAnalytics) {
+                coreAnalytics: CoreAnalytics,
+                serverConfig: ServerConfigProtocol
+    ) {
         self.interactor = interactor
         self.connectivity = connectivity
         self.analytics = analytics
         self.upgradehandler = upgradehandler
         self.coreAnalytics = coreAnalytics
+        self.serverConfig = serverConfig
         
         addObservers()
     }

--- a/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
@@ -126,7 +126,8 @@ public struct PrimaryCourseDashboardView<ProgramView: View>: View {
                                                             lastVisitedBlockID: primary.lastVisitedBlockID
                                                         )
                                                     },
-                                                    isUpgradeable: primary.isUpgradeable,
+                                                    isUpgradeable: primary.isUpgradeable &&
+                                                    viewModel.serverConfig.iapConfig.enabled,
                                                     upgradeAction: {
                                                         Task {@MainActor in
                                                             await self.router.showUpgradeInfo(
@@ -362,7 +363,8 @@ struct PrimaryCourseDashboardView_Previews: PreviewProvider {
             interactor: DashboardInteractor.mock,
             connectivity: Connectivity(),
             analytics: DashboardAnalyticsMock(),
-            config: ConfigMock()
+            config: ConfigMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         PrimaryCourseDashboardView(

--- a/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardViewModel.swift
+++ b/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardViewModel.swift
@@ -30,6 +30,7 @@ public class PrimaryCourseDashboardViewModel: ObservableObject {
     private let interactor: DashboardInteractorProtocol
     private let analytics: DashboardAnalytics
     let config: ConfigProtocol
+    let serverConfig: ServerConfigProtocol
     private var cancellables = Set<AnyCancellable>()
 
     private let ipadPageSize = 7
@@ -39,12 +40,14 @@ public class PrimaryCourseDashboardViewModel: ObservableObject {
         interactor: DashboardInteractorProtocol,
         connectivity: ConnectivityProtocol,
         analytics: DashboardAnalytics,
-        config: ConfigProtocol
+        config: ConfigProtocol,
+        serverConfig: ServerConfigProtocol
     ) {
         self.interactor = interactor
         self.connectivity = connectivity
         self.analytics = analytics
         self.config = config
+        self.serverConfig = serverConfig
         
         let enrollmentPublisher = NotificationCenter.default.publisher(for: .onCourseEnrolled)
         let completionPublisher = NotificationCenter.default.publisher(for: .onblockCompletionRequested)

--- a/Dashboard/DashboardTests/Presentation/DashboardViewModelTests.swift
+++ b/Dashboard/DashboardTests/Presentation/DashboardViewModelTests.swift
@@ -23,7 +23,8 @@ final class ListDashboardViewModelTests: XCTestCase {
             connectivity: connectivity,
             analytics: analytics,
             upgradehandler: CourseUpgradeHandlerProtocolMock(),
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         let items = [
@@ -91,7 +92,8 @@ final class ListDashboardViewModelTests: XCTestCase {
             connectivity: connectivity,
             analytics: analytics,
             upgradehandler: CourseUpgradeHandlerProtocolMock(),
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         let items = [
@@ -159,7 +161,8 @@ final class ListDashboardViewModelTests: XCTestCase {
             connectivity: connectivity,
             analytics: analytics,
             upgradehandler: CourseUpgradeHandlerProtocolMock(),
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         Given(connectivity, .isInternetAvaliable(getter: true))
@@ -183,7 +186,8 @@ final class ListDashboardViewModelTests: XCTestCase {
             connectivity: connectivity,
             analytics: analytics,
             upgradehandler: CourseUpgradeHandlerProtocolMock(),
-            coreAnalytics: CoreAnalyticsMock()
+            coreAnalytics: CoreAnalyticsMock(),
+            serverConfig: ServerConfigProtocolMock()
         )
         
         Given(connectivity, .isInternetAvaliable(getter: true))

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -169,7 +169,8 @@ class ScreenAssembly: Assembly {
                 connectivity: r.resolve(ConnectivityProtocol.self)!,
                 analytics: r.resolve(DashboardAnalytics.self)!,
                 upgradehandler: r.resolve(CourseUpgradeHandlerProtocol.self)!,
-                coreAnalytics: r.resolve(CoreAnalytics.self)!
+                coreAnalytics: r.resolve(CoreAnalytics.self)!,
+                serverConfig: r.resolve(ServerConfigProtocol.self)!
             )
         }
         
@@ -178,7 +179,8 @@ class ScreenAssembly: Assembly {
                 interactor: r.resolve(DashboardInteractorProtocol.self)!,
                 connectivity: r.resolve(ConnectivityProtocol.self)!,
                 analytics: r.resolve(DashboardAnalytics.self)!,
-                config: r.resolve(ConfigProtocol.self)!
+                config: r.resolve(ConfigProtocol.self)!,
+                serverConfig: r.resolve(ServerConfigProtocol.self)!
             )
         }
         
@@ -314,7 +316,8 @@ class ScreenAssembly: Assembly {
                 enrollmentEnd: enrollmentEnd,
                 lastVisitedBlockID: lastVisitedBlockID,
                 coreAnalytics: r.resolve(CoreAnalytics.self)!,
-                selection: selection
+                selection: selection,
+                serverConfig: r.resolve(ServerConfigProtocol.self)!
             )
         }
         

--- a/Profile/ProfileTests/ProfileMock.generated.swift
+++ b/Profile/ProfileTests/ProfileMock.generated.swift
@@ -3292,9 +3292,9 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
     }
 
     open func profileTrackEvent(_ event: AnalyticsEvent, biValue: EventBIValue) {
-        addInvocation(.m_profileEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>.value(`event`), Parameter<EventBIValue>.value(biValue)))
-		let perform = methodPerformValue(.m_profileEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>.value(`event`), Parameter<EventBIValue>.value(biValue))) as? (AnalyticsEvent, EventBIValue) -> Void
-		perform?(`event`, biValue)
+        addInvocation(.m_profileTrackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>.value(`event`), Parameter<EventBIValue>.value(`biValue`)))
+		let perform = methodPerformValue(.m_profileTrackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>.value(`event`), Parameter<EventBIValue>.value(`biValue`))) as? (AnalyticsEvent, EventBIValue) -> Void
+		perform?(`event`, `biValue`)
     }
 
     open func profileScreenEvent(_ event: AnalyticsEvent, biValue: EventBIValue) {
@@ -3320,7 +3320,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
         case m_profileWifiToggle__action_action(Parameter<String>)
         case m_profileUserDeleteAccountClicked
         case m_profileDeleteAccountSuccess__success_success(Parameter<Bool>)
-        case m_profileEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
+        case m_profileTrackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_profileScreenEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -3367,7 +3367,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSuccess, rhs: rhsSuccess, with: matcher), lhsSuccess, rhsSuccess, "success"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_profileEvent__eventbiValue_biValue(let lhsEvent, let lhsBivalue), .m_profileEvent__eventbiValue_biValue(let rhsEvent, let rhsBivalue)):
+            case (.m_profileTrackEvent__eventbiValue_biValue(let lhsEvent, let lhsBivalue), .m_profileTrackEvent__eventbiValue_biValue(let rhsEvent, let rhsBivalue)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBivalue, rhs: rhsBivalue, with: matcher), lhsBivalue, rhsBivalue, "biValue"))
@@ -3399,7 +3399,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
             case let .m_profileWifiToggle__action_action(p0): return p0.intValue
             case .m_profileUserDeleteAccountClicked: return 0
             case let .m_profileDeleteAccountSuccess__success_success(p0): return p0.intValue
-            case let .m_profileEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
+            case let .m_profileTrackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_profileScreenEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             }
         }
@@ -3420,7 +3420,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
             case .m_profileWifiToggle__action_action: return ".profileWifiToggle(action:)"
             case .m_profileUserDeleteAccountClicked: return ".profileUserDeleteAccountClicked()"
             case .m_profileDeleteAccountSuccess__success_success: return ".profileDeleteAccountSuccess(success:)"
-            case .m_profileEvent__eventbiValue_biValue: return ".profileEvent(_:biValue:)"
+            case .m_profileTrackEvent__eventbiValue_biValue: return ".profileTrackEvent(_:biValue:)"
             case .m_profileScreenEvent__eventbiValue_biValue: return ".profileScreenEvent(_:biValue:)"
             }
         }
@@ -3455,7 +3455,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
         public static func profileWifiToggle(action: Parameter<String>) -> Verify { return Verify(method: .m_profileWifiToggle__action_action(`action`))}
         public static func profileUserDeleteAccountClicked() -> Verify { return Verify(method: .m_profileUserDeleteAccountClicked)}
         public static func profileDeleteAccountSuccess(success: Parameter<Bool>) -> Verify { return Verify(method: .m_profileDeleteAccountSuccess__success_success(`success`))}
-        public static func profileEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_profileEvent__eventbiValue_biValue(`event`, `biValue`))}
+        public static func profileTrackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_profileTrackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func profileScreenEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_profileScreenEvent__eventbiValue_biValue(`event`, `biValue`))}
     }
 
@@ -3508,8 +3508,8 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
         public static func profileDeleteAccountSuccess(success: Parameter<Bool>, perform: @escaping (Bool) -> Void) -> Perform {
             return Perform(method: .m_profileDeleteAccountSuccess__success_success(`success`), performs: perform)
         }
-        public static func profileEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>, perform: @escaping (AnalyticsEvent, EventBIValue) -> Void) -> Perform {
-            return Perform(method: .m_profileEvent__eventbiValue_biValue(`event`, `biValue`), performs: perform)
+        public static func profileTrackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>, perform: @escaping (AnalyticsEvent, EventBIValue) -> Void) -> Perform {
+            return Perform(method: .m_profileTrackEvent__eventbiValue_biValue(`event`, `biValue`), performs: perform)
         }
         public static func profileScreenEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>, perform: @escaping (AnalyticsEvent, EventBIValue) -> Void) -> Perform {
             return Perform(method: .m_profileScreenEvent__eventbiValue_biValue(`event`, `biValue`), performs: perform)


### PR DESCRIPTION
Make IAP feature server config dependent returns in the enrollments API `(/api/mobile/v4/users/{usern_ame}/course_enrollments/)`
