### PR TITLE
chore: remove snack bar error for course dates info API on course home

### DIFF
--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -268,7 +268,9 @@ public class CourseContainerViewModel: BaseCourseViewModel {
             withAnimation {
                 self.courseDeadlineInfo = courseDeadlineInfo
             }
-        } catch {}
+        } catch let error {
+            debugLog(error.localizedDescription)
+        }
     }
 
     @MainActor

--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -268,13 +268,7 @@ public class CourseContainerViewModel: BaseCourseViewModel {
             withAnimation {
                 self.courseDeadlineInfo = courseDeadlineInfo
             }
-        } catch let error {
-            if error.isInternetError || error is NoCachedDataError {
-                errorMessage = CoreLocalization.Error.slowOrNoInternetConnection
-            } else {
-                errorMessage = CoreLocalization.Error.unknownError
-            }
-        }
+        } catch {}
     }
 
     @MainActor


### PR DESCRIPTION
Don’t show the error snack bar on the failure of API /api/course_experience/v1/course_deadlines_info/ because it’s a supportive API and on failure of this user can still have full access to the course content.