### PR TITLE
fix: open link in Safari if link has target blank

### DIFF
--- a/Core/Core/View/Base/Webview/WebView.swift
+++ b/Core/Core/View/Base/Webview/WebView.swift
@@ -146,7 +146,7 @@ public struct WebView: UIViewRepresentable {
             
             let baseURL = await parent.viewModel.baseURL
             switch navigationAction.navigationType {
-            case .other:
+            case .other, .formSubmitted:
                 return .allow
             case .linkActivated:
                 await MainActor.run {
@@ -155,8 +155,6 @@ public struct WebView: UIViewRepresentable {
                     }
                 }
                 return .cancel
-            case .formSubmitted:
-                return .allow
             default:
                 if !baseURL.isEmpty, !url.absoluteString.starts(with: baseURL) {
                     return .cancel

--- a/Core/Core/View/Base/Webview/WebView.swift
+++ b/Core/Core/View/Base/Webview/WebView.swift
@@ -150,7 +150,9 @@ public struct WebView: UIViewRepresentable {
                 return .allow
             case .linkActivated:
                 await MainActor.run {
-                    UIApplication.shared.open(url, options: [:])
+                    if UIApplication.shared.canOpenURL(url) {
+                        UIApplication.shared.open(url, options: [:])
+                    }
                 }
                 return .cancel
             case .formSubmitted:

--- a/Core/Core/View/Base/Webview/WebView.swift
+++ b/Core/Core/View/Base/Webview/WebView.swift
@@ -146,7 +146,7 @@ public struct WebView: UIViewRepresentable {
             
             let baseURL = await parent.viewModel.baseURL
             switch navigationAction.navigationType {
-            case .other, .formSubmitted:
+            case .other, .formSubmitted, .formResubmitted:
                 return .allow
             case .linkActivated:
                 await MainActor.run {

--- a/Core/Core/View/Base/Webview/WebView.swift
+++ b/Core/Core/View/Base/Webview/WebView.swift
@@ -127,6 +127,19 @@ public struct WebView: UIViewRepresentable {
         }
 
         public func webView(
+            _ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            if navigationAction.targetFrame == nil, let url = navigationAction.request.url {
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            return nil
+        }
+
+        public func webView(
             _ webView: WKWebView,
             decidePolicyFor navigationAction: WKNavigationAction
         ) async -> WKNavigationActionPolicy {


### PR DESCRIPTION
This PR fixes issue https://github.com/openedx/openedx-app-ios/issues/502
When tag <a> contains `target="_blank"` we open this link in Safari browser