### PR TITLE
fix: snack bar and resume course button color fix for light dark modes

### DIFF
--- a/Core/Core/View/Base/OfflineSnackBarView.swift
+++ b/Core/Core/View/Base/OfflineSnackBarView.swift
@@ -29,23 +29,29 @@ public struct OfflineSnackBarView: View {
                 HStack(spacing: 12) {
                     Text(CoreLocalization.NoInternet.offline)
                         .accessibilityIdentifier("no_internet_text")
+                        .foregroundColor(Theme.Colors.snackbarTextColor)
                     Spacer()
-                    Button(CoreLocalization.NoInternet.dismiss,
-                           action: {
+                    Button(action: {
                         withAnimation {
                             dismiss = true
                         }
+                    }, label: {
+                        Text(CoreLocalization.NoInternet.dismiss)
+                            .foregroundColor(Theme.Colors.snackbarTextColor)
                     })
                     .accessibilityIdentifier("no_internet_dismiss_button")
-                    Button(CoreLocalization.NoInternet.reload,
-                           action: {
+                    Button(action: {
                         Task {
                             await reloadAction()
                         }
                         withAnimation {
                             dismiss = true
                         }
-                    })
+                    },label: {
+                        Text(CoreLocalization.NoInternet.reload)
+                            .foregroundColor(Theme.Colors.snackbarTextColor)
+                    }
+                    )
                     .accessibilityIdentifier("no_internet_reload_button")
                 }.padding(.horizontal, 16)
                     .font(Theme.Fonts.titleSmall)

--- a/Core/Core/View/Base/OfflineSnackBarView.swift
+++ b/Core/Core/View/Base/OfflineSnackBarView.swift
@@ -35,7 +35,7 @@ public struct OfflineSnackBarView: View {
                         withAnimation {
                             dismiss = true
                         }
-                    },label: {
+                    }, label: {
                         Text(CoreLocalization.NoInternet.dismiss)
                             .foregroundColor(Theme.Colors.snackbarTextColor)
                     })
@@ -47,7 +47,7 @@ public struct OfflineSnackBarView: View {
                         withAnimation {
                             dismiss = true
                         }
-                    },label: {
+                    }, label: {
                         Text(CoreLocalization.NoInternet.reload)
                             .foregroundColor(Theme.Colors.snackbarTextColor)
                     }

--- a/Core/Core/View/Base/OfflineSnackBarView.swift
+++ b/Core/Core/View/Base/OfflineSnackBarView.swift
@@ -35,7 +35,7 @@ public struct OfflineSnackBarView: View {
                         withAnimation {
                             dismiss = true
                         }
-                    }, label: {
+                    },label: {
                         Text(CoreLocalization.NoInternet.dismiss)
                             .foregroundColor(Theme.Colors.snackbarTextColor)
                     })

--- a/Core/Core/View/Base/UnitButtonView.swift
+++ b/Core/Core/View/Base/UnitButtonView.swift
@@ -151,7 +151,11 @@ public struct UnitButtonView: View {
                                 .padding(.leading, 20)
                                 .font(Theme.Fonts.labelLarge)
                             CoreAssets.arrowLeft.swiftUIImage.renderingMode(.template)
-                                .foregroundColor(Theme.Colors.styledButtonText)
+                                .foregroundColor(
+                                        type == .continueLesson
+                                        ? Theme.Colors.accentColor
+                                        : Theme.Colors.styledButtonText
+                                    )
                                 .rotationEffect(Angle.degrees(180))
                                 .padding(.trailing, 20)
                         }


### PR DESCRIPTION
This PR addresses the following issues: 

1. Text in Offline panel are not visible in Dark mode
2. Missed arrow for Resume button in light mode
