### PR TITLE
chore: show unsupported error screen for gated content

### DIFF
--- a/Core/Core/Domain/Model/CourseBlockModel.swift
+++ b/Core/Core/Domain/Model/CourseBlockModel.swift
@@ -240,6 +240,7 @@ public struct CourseVertical: Identifiable, Hashable {
     public let type: BlockType
     public let completion: Double
     public var childs: [CourseBlock]
+    public var webUrl: String
     
     public var isDownloadable: Bool {
         return childs.first(where: { $0.isDownloadable }) != nil
@@ -252,7 +253,8 @@ public struct CourseVertical: Identifiable, Hashable {
         displayName: String,
         type: BlockType,
         completion: Double,
-        childs: [CourseBlock]
+        childs: [CourseBlock],
+        webUrl: String
     ) {
         self.blockId = blockId
         self.id = id
@@ -261,6 +263,7 @@ public struct CourseVertical: Identifiable, Hashable {
         self.type = type
         self.completion = completion
         self.childs = childs
+        self.webUrl = webUrl
     }
 }
 

--- a/Course/Course.xcodeproj/project.pbxproj
+++ b/Course/Course.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		02454CA02A2618E70043052A /* YouTubeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02454C9F2A2618E70043052A /* YouTubeView.swift */; };
 		02454CA22A26190A0043052A /* EncodedVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02454CA12A26190A0043052A /* EncodedVideoView.swift */; };
 		02454CA42A26193F0043052A /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02454CA32A26193F0043052A /* WebView.swift */; };
-		02454CA62A26196C0043052A /* UnknownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02454CA52A26196C0043052A /* UnknownView.swift */; };
+		02454CA62A26196C0043052A /* NotAvailableOnMobileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02454CA52A26196C0043052A /* NotAvailableOnMobileView.swift */; };
 		02454CA82A2619890043052A /* DiscussionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02454CA72A2619890043052A /* DiscussionView.swift */; };
 		02454CAA2A2619B40043052A /* LessonProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02454CA92A2619B40043052A /* LessonProgressView.swift */; };
 		0248C92729C097EB00DC8402 /* CourseVerticalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248C92629C097EB00DC8402 /* CourseVerticalViewModel.swift */; };
@@ -129,7 +129,7 @@
 		02454C9F2A2618E70043052A /* YouTubeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeView.swift; sourceTree = "<group>"; };
 		02454CA12A26190A0043052A /* EncodedVideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodedVideoView.swift; sourceTree = "<group>"; };
 		02454CA32A26193F0043052A /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
-		02454CA52A26196C0043052A /* UnknownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownView.swift; sourceTree = "<group>"; };
+		02454CA52A26196C0043052A /* NotAvailableOnMobileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotAvailableOnMobileView.swift; sourceTree = "<group>"; };
 		02454CA72A2619890043052A /* DiscussionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionView.swift; sourceTree = "<group>"; };
 		02454CA92A2619B40043052A /* LessonProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonProgressView.swift; sourceTree = "<group>"; };
 		0248C92629C097EB00DC8402 /* CourseVerticalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseVerticalViewModel.swift; sourceTree = "<group>"; };
@@ -278,7 +278,7 @@
 				02454C9F2A2618E70043052A /* YouTubeView.swift */,
 				02454CA12A26190A0043052A /* EncodedVideoView.swift */,
 				02454CA32A26193F0043052A /* WebView.swift */,
-				02454CA52A26196C0043052A /* UnknownView.swift */,
+				02454CA52A26196C0043052A /* NotAvailableOnMobileView.swift */,
 				02454CA72A2619890043052A /* DiscussionView.swift */,
 				02454CA92A2619B40043052A /* LessonProgressView.swift */,
 				BAD9CA2C2B2736BB00DE790A /* LessonLineProgressView.swift */,
@@ -920,7 +920,7 @@
 				BA58CF5D2B3D804D005B102E /* CourseStorage.swift in Sources */,
 				067B7B502BED339200D1768F /* PlayerControllerProtocol.swift in Sources */,
 				067B7B4E2BED339200D1768F /* PlayerTrackerProtocol.swift in Sources */,
-				02454CA62A26196C0043052A /* UnknownView.swift in Sources */,
+				02454CA62A26196C0043052A /* NotAvailableOnMobileView.swift in Sources */,
 				0766DFD0299AB29000EBEF6A /* PlayerViewController.swift in Sources */,
 				022C64DC29ACFDEE000F532B /* Data_HandoutsResponse.swift in Sources */,
 				022C64D829ACEC48000F532B /* HandoutsView.swift in Sources */,

--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -232,7 +232,8 @@ public class CourseRepository: CourseRepositoryProtocol {
             displayName: sequential.displayName,
             type: BlockType(rawValue: sequential.type) ?? .unknown,
             completion: sequential.completion ?? 0,
-            childs: childs
+            childs: childs,
+            webUrl: sequential.webUrl
         )
     }
     
@@ -485,7 +486,8 @@ And there are various ways of describing it-- call it oral poetry or
             displayName: sequential.displayName,
             type: BlockType(rawValue: sequential.type) ?? .unknown,
             completion: sequential.completion ?? 0,
-            childs: childs
+            childs: childs,
+            webUrl: sequential.webUrl
         )
     }
     

--- a/Course/Course/Domain/CourseInteractor.swift
+++ b/Course/Course/Domain/CourseInteractor.swift
@@ -151,7 +151,8 @@ public class CourseInteractor: CourseInteractorProtocol {
             displayName: vertical.displayName,
             type: vertical.type,
             completion: vertical.completion,
-            childs: newChilds
+            childs: newChilds,
+            webUrl: vertical.webUrl
         )
     }
     

--- a/Course/Course/Presentation/CourseRouter.swift
+++ b/Course/Course/Presentation/CourseRouter.swift
@@ -62,6 +62,8 @@ public protocol CourseRouter: BaseRouter {
     )
     
     func showTabScreen(tab: MainTab)
+    
+    func showGatedContentError(url: String)
 }
 
 // Mark - For testing and SwiftUI preview
@@ -121,6 +123,8 @@ public class CourseRouterMock: BaseRouterMock, CourseRouter {
         manager: Core.DownloadManagerProtocol
     ) {}
     
-    public func showTabScreen(tab: MainTab){}
+    public func showTabScreen(tab: MainTab) {}
+    
+    public func showGatedContentError(url: String) {}
 }
 #endif

--- a/Course/Course/Presentation/Outline/ContinueWithView.swift
+++ b/Course/Course/Presentation/Outline/ContinueWithView.swift
@@ -123,7 +123,8 @@ struct ContinueWithView_Previews: PreviewProvider {
                 displayName: "Second Unit",
                 type: .vertical,
                 completion: 1,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             )
         ) { }
     }

--- a/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalView.swift
+++ b/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalView.swift
@@ -202,8 +202,10 @@ struct CourseVerticalView_Previews: PreviewProvider {
                                 displayName: "Vertical",
                                 type: .vertical,
                                 completion: 0,
-                                childs: [])
-                        ], 
+                                childs: [],
+                                webUrl: ""
+                            )
+                        ],
                         sequentialProgress: SequentialProgress(
                             assignmentType: "Advanced Assessment Tools",
                             numPointsEarned: 1,

--- a/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
+++ b/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
@@ -95,7 +95,10 @@ struct CustomDisclosureGroup: View {
                                                 guard let chapterIndex = chapterIndex else { return }
                                                 guard let sequentialIndex else { return }
                                                 guard let courseVertical = sequential.childs.first else { return }
-                                                guard let block = courseVertical.childs.first else { return }
+                                                guard let block = courseVertical.childs.first else {
+                                                    viewModel.router.showGatedContentError(url: courseVertical.webUrl)
+                                                    return
+                                                }
 
                                                 viewModel.trackSequentialClicked(sequential)
                                                 if viewModel.config.uiComponents.courseDropDownNavigationEnabled {
@@ -278,7 +281,8 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
                                 displayName: "Vertical 1",
                                 type: .vertical,
                                 completion: 0,
-                                childs: []
+                                childs: [],
+                                webUrl: ""
                             ),
                             CourseVertical(
                                 blockId: "1-1-2",
@@ -287,7 +291,8 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
                                 displayName: "Vertical 2",
                                 type: .vertical,
                                 completion: 1.0,
-                                childs: []
+                                childs: [],
+                                webUrl: ""
                             )
                         ],
                         sequentialProgress: SequentialProgress(
@@ -311,7 +316,8 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
                                 displayName: "Vertical 3",
                                 type: .vertical,
                                 completion: 1.0,
-                                childs: []
+                                childs: [],
+                                webUrl: ""
                             )
                         ],
                         sequentialProgress: SequentialProgress(
@@ -343,7 +349,8 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
                                 displayName: "Vertical 4",
                                 type: .vertical,
                                 completion: 1.0,
-                                childs: []
+                                childs: [],
+                                webUrl: ""
                             ),
                             CourseVertical(
                                 blockId: "2-1-2",
@@ -352,7 +359,8 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
                                 displayName: "Vertical 5",
                                 type: .vertical,
                                 completion: 1.0,
-                                childs: []
+                                childs: [],
+                                webUrl: ""
                             )
                         ],
                         sequentialProgress: SequentialProgress(

--- a/Course/Course/Presentation/Unit/CourseUnitView.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitView.swift
@@ -242,7 +242,7 @@ public struct CourseUnitView: View {
                     case .unknown(let url):
                         if index >= viewModel.index - 1 && index <= viewModel.index + 1 {
                             if viewModel.connectivity.isInternetAvaliable {
-                                UnknownView(url: url)
+                                NotAvailableOnMobileView(url: url)
                                     .frameLimit(width: reader.size.width)
                             } else {
                                 FullScreenErrorView(type: .noInternet)

--- a/Course/Course/Presentation/Unit/CourseUnitView.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitView.swift
@@ -242,10 +242,8 @@ public struct CourseUnitView: View {
                     case .unknown(let url):
                         if index >= viewModel.index - 1 && index <= viewModel.index + 1 {
                             if viewModel.connectivity.isInternetAvaliable {
-                                UnknownView(url: url, viewModel: viewModel)
+                                UnknownView(url: url)
                                     .frameLimit(width: reader.size.width)
-                                Spacer()
-                                    .frame(minHeight: 100)
                             } else {
                                 FullScreenErrorView(type: .noInternet)
                             }
@@ -519,7 +517,8 @@ struct CourseUnitView_Previews: PreviewProvider {
                                 displayName: "6",
                                 type: .vertical,
                                 completion: 0,
-                                childs: blocks
+                                childs: blocks,
+                                webUrl: ""
                             )
                         ],
                         sequentialProgress: SequentialProgress(
@@ -552,7 +551,8 @@ struct CourseUnitView_Previews: PreviewProvider {
                                 displayName: "4",
                                 type: .vertical,
                                 completion: 0,
-                                childs: blocks
+                                childs: blocks,
+                                webUrl: ""
                             )
                         ],
                         sequentialProgress: SequentialProgress(

--- a/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitDropDownCell.swift
+++ b/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitDropDownCell.swift
@@ -86,7 +86,8 @@ struct CourseUnitDropDownCell_Previews: PreviewProvider {
                     encodedVideo: nil,
                     multiDevice: true
                 )
-            ]
+            ],
+            webUrl: ""
         )
                
         CourseUnitDropDownCell(

--- a/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitDropDownList.swift
+++ b/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitDropDownList.swift
@@ -115,7 +115,8 @@ struct CourseUnitDropDownList_Previews: PreviewProvider {
                 displayName: "First Unit",
                 type: .vertical,
                 completion: 0,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             ),
             CourseVertical(
                 blockId: "2",
@@ -124,7 +125,8 @@ struct CourseUnitDropDownList_Previews: PreviewProvider {
                 displayName: "Second Unit",
                 type: .vertical,
                 completion: 1,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             ),
             CourseVertical(
                 blockId: "3",
@@ -133,7 +135,8 @@ struct CourseUnitDropDownList_Previews: PreviewProvider {
                 displayName: "Third Unit",
                 type: .vertical,
                 completion: 0,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             ),
             CourseVertical(
                 blockId: "4",
@@ -142,7 +145,8 @@ struct CourseUnitDropDownList_Previews: PreviewProvider {
                 displayName: "Fourth Unit",
                 type: .vertical,
                 completion: 1,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             )
         ]
         

--- a/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitVerticalsDropdownView.swift
+++ b/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitVerticalsDropdownView.swift
@@ -131,7 +131,8 @@ struct CourseUnitVerticalsDropdownView_Previews: PreviewProvider {
                 displayName: "First Unit",
                 type: .vertical,
                 completion: 0,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             ),
             CourseVertical(
                 blockId: "2",
@@ -140,7 +141,8 @@ struct CourseUnitVerticalsDropdownView_Previews: PreviewProvider {
                 displayName: "Second Unit",
                 type: .vertical,
                 completion: 1,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             ),
             CourseVertical(
                 blockId: "3",
@@ -149,7 +151,8 @@ struct CourseUnitVerticalsDropdownView_Previews: PreviewProvider {
                 displayName: "Third Unit",
                 type: .vertical,
                 completion: 0,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             ),
             CourseVertical(
                 blockId: "4",
@@ -158,7 +161,8 @@ struct CourseUnitVerticalsDropdownView_Previews: PreviewProvider {
                 displayName: "Fourth Unit",
                 type: .vertical,
                 completion: 1,
-                childs: blocks
+                childs: blocks,
+                webUrl: ""
             )
         ]
         

--- a/Course/Course/Presentation/Unit/Subviews/NotAvailableOnMobileView.swift
+++ b/Course/Course/Presentation/Unit/Subviews/NotAvailableOnMobileView.swift
@@ -1,5 +1,5 @@
 //
-//  UnknownView.swift
+//  NotAvailableOnMobileView.swift
 //  Course
 //
 //  Created by  Stepanok Ivan on 30.05.2023.
@@ -9,7 +9,7 @@ import SwiftUI
 import Core
 import Theme
 
-public struct UnknownView: View {
+public struct NotAvailableOnMobileView: View {
     let url: String
     
     public init(url: String) {
@@ -30,7 +30,7 @@ public struct UnknownView: View {
                     .multilineTextAlignment(.center)
                     .padding(.top, 12)
                 StyledButton(CourseLocalization.NotAvaliable.button, action: {
-                    if let url = URL(string: url) {
+                    if let url = URL(string: url), UIApplication.shared.canOpenURL(url) {
                         UIApplication.shared.open(url)
                     }
                 })

--- a/Course/Course/Presentation/Unit/Subviews/UnknownView.swift
+++ b/Course/Course/Presentation/Unit/Subviews/UnknownView.swift
@@ -9,33 +9,37 @@ import SwiftUI
 import Core
 import Theme
 
-struct UnknownView: View {
+public struct UnknownView: View {
     let url: String
-    let viewModel: CourseUnitViewModel
     
-    var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            CoreAssets.notAvaliable.swiftUIImage
-            Text(CourseLocalization.NotAvaliable.title)
-                .font(Theme.Fonts.titleLarge)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity)
+    public init(url: String) {
+        self.url = url
+    }
+    
+    public var body: some View {
+        ZStack(alignment: .center) {
+            VStack(spacing: 10) {
+                Spacer()
+                CoreAssets.notAvaliable.swiftUIImage
+                Text(CourseLocalization.NotAvaliable.title)
+                    .font(Theme.Fonts.titleLarge)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 40)
+                Text(CourseLocalization.NotAvaliable.description)
+                    .font(Theme.Fonts.bodyLarge)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 12)
+                StyledButton(CourseLocalization.NotAvaliable.button, action: {
+                    if let url = URL(string: url) {
+                        UIApplication.shared.open(url)
+                    }
+                })
+                .frame(width: 215)
                 .padding(.top, 40)
-            Text(CourseLocalization.NotAvaliable.description)
-                .font(Theme.Fonts.bodyLarge)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity)
-                .padding(.top, 12)
-            StyledButton(CourseLocalization.NotAvaliable.button, action: {
-                if let url = URL(string: url) {
-                    UIApplication.shared.open(url)
-                }
-            })
-            .frame(width: 215)
-            .padding(.top, 40)
-            Spacer()
+                Spacer()
+            }
+            .padding(24)
         }
-        .padding(24)
+        .navigationBarHidden(false)
     }
 }

--- a/Course/CourseTests/Presentation/Container/CourseContainerViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Container/CourseContainerViewModelTests.swift
@@ -67,7 +67,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             displayName: "",
             type: .vertical,
             completion: 0,
-            childs: [block]
+            childs: [block],
+            webUrl: ""
         )
         let sequential = CourseSequential(
             blockId: "",
@@ -410,7 +411,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             displayName: "",
             type: .vertical,
             completion: 0,
-            childs: [block]
+            childs: [block],
+            webUrl: ""
         )
 
         let sequential = CourseSequential(
@@ -556,7 +558,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             displayName: "",
             type: .vertical,
             completion: 0,
-            childs: [block]
+            childs: [block],
+            webUrl: ""
         )
 
         let sequential = CourseSequential(
@@ -687,7 +690,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             displayName: "",
             type: .vertical,
             completion: 0,
-            childs: [block]
+            childs: [block],
+            webUrl: ""
         )
 
         let sequential = CourseSequential(
@@ -819,7 +823,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             displayName: "",
             type: .vertical,
             completion: 0,
-            childs: [block]
+            childs: [block],
+            webUrl: ""
         )
 
         let sequential = CourseSequential(
@@ -944,7 +949,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             displayName: "",
             type: .vertical,
             completion: 0,
-            childs: [block]
+            childs: [block],
+            webUrl: ""
         )
 
         let sequential = CourseSequential(
@@ -1084,7 +1090,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             displayName: "",
             type: .vertical,
             completion: 0,
-            childs: [block]
+            childs: [block],
+            webUrl: ""
         )
 
         let sequential = CourseSequential(
@@ -1245,7 +1252,8 @@ final class CourseContainerViewModelTests: XCTestCase {
             displayName: "",
             type: .vertical,
             completion: 0,
-            childs: [block, block2]
+            childs: [block, block2],
+            webUrl: ""
         )
 
         let sequential = CourseSequential(

--- a/Course/CourseTests/Presentation/Unit/CourseUnitViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Unit/CourseUnitViewModelTests.swift
@@ -81,23 +81,27 @@ final class CourseUnitViewModelTests: XCTestCase {
         displayName: "0",
         type: .chapter,
         childs: [
-            CourseSequential(blockId: "5",
-                             id: "5",
-                             displayName: "5",
-                             type: .sequential,
-                             completion: 0,
-                             childs: [
-                                CourseVertical(blockId: "6",
-                                               id: "6",
-                                               courseId: "123",
-                                               displayName: "6",
-                                               type: .vertical,
-                                               completion: 0,
-                                               childs: blocks)
-                             ], 
-                             sequentialProgress: nil, 
-                             due: Date()
-                            )
+            CourseSequential(
+                blockId: "5",
+                id: "5",
+                displayName: "5",
+                type: .sequential,
+                completion: 0,
+                childs: [
+                    CourseVertical(
+                        blockId: "6",
+                        id: "6",
+                        courseId: "123",
+                        displayName: "6",
+                        type: .vertical,
+                        completion: 0,
+                        childs: blocks,
+                        webUrl: ""
+                    )
+                ],
+                sequentialProgress: nil,
+                due: Date()
+            )
             
         ]),
         CourseChapter(
@@ -106,23 +110,27 @@ final class CourseUnitViewModelTests: XCTestCase {
         displayName: "2",
         type: .chapter,
         childs: [
-            CourseSequential(blockId: "3",
-                             id: "3",
-                             displayName: "3",
-                             type: .sequential,
-                             completion: 0,
-                             childs: [
-                                CourseVertical(blockId: "4",
-                                               id: "4",
-                                               courseId: "123",
-                                               displayName: "4",
-                                               type: .vertical,
-                                               completion: 0,
-                                               childs: blocks)
-                             ],
-                             sequentialProgress: nil,
-                             due: Date()
-                            )
+            CourseSequential(
+                blockId: "3",
+                id: "3",
+                displayName: "3",
+                type: .sequential,
+                completion: 0,
+                childs: [
+                    CourseVertical(
+                        blockId: "4",
+                        id: "4",
+                        courseId: "123",
+                        displayName: "4",
+                        type: .vertical,
+                        completion: 0,
+                        childs: blocks,
+                        webUrl: ""
+                    )
+                ],
+                sequentialProgress: nil,
+                due: Date()
+            )
             
         ])
         ]

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -559,7 +559,7 @@ public class Router: AuthorizationRouter,
         }
     
     public func showGatedContentError(url: String) {
-        let view = UnknownView(url: url)
+        let view = NotAvailableOnMobileView(url: url)
         
         let controller = UIHostingController(rootView: view)
         navigationController.pushViewController(controller, animated: true)

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -558,6 +558,13 @@ public class Router: AuthorizationRouter,
             }
         }
     
+    public func showGatedContentError(url: String) {
+        let view = UnknownView(url: url)
+        
+        let controller = UIHostingController(rootView: view)
+        navigationController.pushViewController(controller, animated: true)
+    }
+    
     private func openBlockInBrowser(blockURL: URL) {
         presentAlert(
             alertTitle: "",


### PR DESCRIPTION
This PR address the following Issue

```
"Learn > Courses > Any audit track course (ex: IBM's The Data Science Method) > Course Home

Tabbing on locked content (such as graded assignments and quiz) in the module doesn't prompt anything"