### PR TITLE
chore: add my to view all courses

### DIFF
--- a/Dashboard/Dashboard/SwiftGen/Strings.swift
+++ b/Dashboard/Dashboard/SwiftGen/Strings.swift
@@ -34,9 +34,9 @@ public enum DashboardLocalization {
     public static let title = DashboardLocalization.tr("Localizable", "LEARN.TITLE", fallback: "Learn")
     /// View All
     public static let viewAll = DashboardLocalization.tr("Localizable", "LEARN.VIEW_ALL", fallback: "View All")
-    /// View All Courses (%@)
+    /// View All My Courses (%@)
     public static func viewAllCourses(_ p1: Any) -> String {
-      return DashboardLocalization.tr("Localizable", "LEARN.VIEW_ALL_COURSES", String(describing: p1), fallback: "View All Courses (%@)")
+      return DashboardLocalization.tr("Localizable", "LEARN.VIEW_ALL_COURSES", String(describing: p1), fallback: "View All My Courses (%@)")
     }
     public enum Category {
       /// All

--- a/Dashboard/Dashboard/SwiftGen/Strings.swift
+++ b/Dashboard/Dashboard/SwiftGen/Strings.swift
@@ -28,8 +28,8 @@ public enum DashboardLocalization {
     public static let welcomeBack = DashboardLocalization.tr("Localizable", "HEADER.WELCOME_BACK", fallback: "Welcome back. Let's keep learning.")
   }
   public enum Learn {
-    /// All Courses
-    public static let allCourses = DashboardLocalization.tr("Localizable", "LEARN.ALL_COURSES", fallback: "All Courses")
+    /// All My Courses
+    public static let allCourses = DashboardLocalization.tr("Localizable", "LEARN.ALL_COURSES", fallback: "All My Courses")
     /// Learn
     public static let title = DashboardLocalization.tr("Localizable", "LEARN.TITLE", fallback: "Learn")
     /// View All

--- a/Dashboard/Dashboard/en.lproj/Localizable.strings
+++ b/Dashboard/Dashboard/en.lproj/Localizable.strings
@@ -17,7 +17,7 @@
 "LEARN.TITLE" = "Learn";
 "LEARN.VIEW_ALL" = "View All";
 "LEARN.VIEW_ALL_COURSES" = "View All My Courses (%@)";
-"LEARN.ALL_COURSES" = "All Courses";
+"LEARN.ALL_COURSES" = "All My Courses";
 
 "LEARN.PRIMARY_CARD.ONE_PAST_ASSIGNMENT" = "1 Past Due Assignment";
 "LEARN.PRIMARY_CARD.VIEW_ASSIGNMENTS" = "View Assignments";

--- a/Dashboard/Dashboard/en.lproj/Localizable.strings
+++ b/Dashboard/Dashboard/en.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 
 "LEARN.TITLE" = "Learn";
 "LEARN.VIEW_ALL" = "View All";
-"LEARN.VIEW_ALL_COURSES" = "View All Courses (%@)";
+"LEARN.VIEW_ALL_COURSES" = "View All My Courses (%@)";
 "LEARN.ALL_COURSES" = "All Courses";
 
 "LEARN.PRIMARY_CARD.ONE_PAST_ASSIGNMENT" = "1 Past Due Assignment";

--- a/Dashboard/Dashboard/uk.lproj/Localizable.strings
+++ b/Dashboard/Dashboard/uk.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 
 "LEARN.TITLE" = "Навчання";
 "LEARN.VIEW_ALL" = "Переглянути все (%@)";
+"LEARN.VIEW_ALL_COURSES" = "View All My Courses (%@)";
 "LEARN.ALL_COURSES" = "Усі курси";
 
 "LEARN.PRIMARY_CARD.ONE_PAST_ASSIGNMENT" = "1 прострочене завдання";

--- a/Dashboard/Dashboard/uk.lproj/Localizable.strings
+++ b/Dashboard/Dashboard/uk.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "LEARN.TITLE" = "Навчання";
 "LEARN.VIEW_ALL" = "Переглянути все (%@)";
 "LEARN.VIEW_ALL_COURSES" = "View All My Courses (%@)";
-"LEARN.ALL_COURSES" = "Усі курси";
+"LEARN.ALL_COURSES" = "All My Courses";
 
 "LEARN.PRIMARY_CARD.ONE_PAST_ASSIGNMENT" = "1 прострочене завдання";
 "LEARN.PRIMARY_CARD.VIEW_ASSIGNMENTS" = "Переглянути завдання";


### PR DESCRIPTION
This PR fixes teh following issue

```
"Learn > Courses > ""View All Courses (149)"" 

The header for this screen reads ""All Courses"" and is missing ""My"" after ""All"""
```