### PR TITLE
feat: eye icon for password field

### DIFF
--- a/Authorization/Authorization/Presentation/Login/SignInView.swift
+++ b/Authorization/Authorization/Presentation/Login/SignInView.swift
@@ -102,7 +102,7 @@ public struct SignInView: View {
                                     .foregroundColor(Theme.Colors.textPrimary)
                                     .padding(.top, 18)
                                     .accessibilityIdentifier("password_text")
-                                SecureField("", text: $password)
+                                SecureInputView($password)
                                     .font(Theme.Fonts.bodyLarge)
                                     .foregroundColor(Theme.Colors.textInputTextColor)
                                     .padding(.all, 14)

--- a/Authorization/Authorization/Presentation/Login/SignInView.swift
+++ b/Authorization/Authorization/Presentation/Login/SignInView.swift
@@ -104,7 +104,6 @@ public struct SignInView: View {
                                     .accessibilityIdentifier("password_text")
                                 SecureInputView($password)
                                     .font(Theme.Fonts.bodyLarge)
-                                    .foregroundColor(Theme.Colors.textInputTextColor)
                                     .padding(.all, 14)
                                     .background(
                                         Theme.InputFieldBackground(

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -175,15 +175,16 @@
 		14A832632BD8D54100E5654D /* Dictionary+SafeAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A832622BD8D54100E5654D /* Dictionary+SafeAccess.swift */; };
 		14A832662BD8D5BD00E5654D /* Dictionary+SafeAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A832652BD8D5BD00E5654D /* Dictionary+SafeAccessTests.swift */; };
 		14A832682BDA8B6000E5654D /* UIAlertController+BlockActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A832672BDA8B6000E5654D /* UIAlertController+BlockActions.swift */; };
+		14D912D92C2553C70077CCCE /* FullStoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D912D82C2553C70077CCCE /* FullStoryConfig.swift */; };
+		14D912DB2C257E9E0077CCCE /* FullStoryConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D912DA2C257E9E0077CCCE /* FullStoryConfigTests.swift */; };
 		14DE13DA2BDF7E5E0059168F /* IAPConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DE13D92BDF7E5E0059168F /* IAPConfig.swift */; };
 		14DE13DC2BDF83350059168F /* ServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DE13DB2BDF83350059168F /* ServerConfig.swift */; };
 		14F8E66B2C0F4D1200E4EF69 /* RestoreInProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F8E66A2C0F4D1200E4EF69 /* RestoreInProgressView.swift */; };
-		14D912D92C2553C70077CCCE /* FullStoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D912D82C2553C70077CCCE /* FullStoryConfig.swift */; };
-		14D912DB2C257E9E0077CCCE /* FullStoryConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D912DA2C257E9E0077CCCE /* FullStoryConfigTests.swift */; };
 		9784D47E2BF7762800AFEFFF /* FullScreenErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9784D47D2BF7762800AFEFFF /* FullScreenErrorView.swift */; };
 		A51CDBE72B6D21F2009B6D4E /* SegmentConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51CDBE62B6D21F2009B6D4E /* SegmentConfig.swift */; };
 		A53A32352B233DEC005FE38A /* ThemeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53A32342B233DEC005FE38A /* ThemeConfig.swift */; };
 		A595689B2B6173DF00ED4F90 /* BranchConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A595689A2B6173DF00ED4F90 /* BranchConfig.swift */; };
+		A5CAA1EC2C526901007690D9 /* SecureInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CAA1EB2C526901007690D9 /* SecureInputView.swift */; };
 		A5F4E7B52B61544A00ACD166 /* BrazeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F4E7B42B61544A00ACD166 /* BrazeConfig.swift */; };
 		BA30427F2B20B320009B64B7 /* SocialAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA30427D2B20B299009B64B7 /* SocialAuthError.swift */; };
 		BA4AFB422B5A7A0900A21367 /* VideoDownloadQualityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4AFB412B5A7A0900A21367 /* VideoDownloadQualityView.swift */; };
@@ -401,11 +402,11 @@
 		14A832622BD8D54100E5654D /* Dictionary+SafeAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+SafeAccess.swift"; sourceTree = "<group>"; };
 		14A832652BD8D5BD00E5654D /* Dictionary+SafeAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+SafeAccessTests.swift"; sourceTree = "<group>"; };
 		14A832672BDA8B6000E5654D /* UIAlertController+BlockActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+BlockActions.swift"; sourceTree = "<group>"; };
+		14D912D82C2553C70077CCCE /* FullStoryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullStoryConfig.swift; sourceTree = "<group>"; };
+		14D912DA2C257E9E0077CCCE /* FullStoryConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullStoryConfigTests.swift; sourceTree = "<group>"; };
 		14DE13D92BDF7E5E0059168F /* IAPConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPConfig.swift; sourceTree = "<group>"; };
 		14DE13DB2BDF83350059168F /* ServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConfig.swift; sourceTree = "<group>"; };
 		14F8E66A2C0F4D1200E4EF69 /* RestoreInProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreInProgressView.swift; sourceTree = "<group>"; };
-		14D912D82C2553C70077CCCE /* FullStoryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullStoryConfig.swift; sourceTree = "<group>"; };
-		14D912DA2C257E9E0077CCCE /* FullStoryConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullStoryConfigTests.swift; sourceTree = "<group>"; };
 		1A154A95AF4EE85A4A1C083B /* Pods-App-Core.releasedev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Core.releasedev.xcconfig"; path = "Target Support Files/Pods-App-Core/Pods-App-Core.releasedev.xcconfig"; sourceTree = "<group>"; };
 		2B7E6FE7843FC4CF2BFA712D /* Pods-App-Core.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Core.debug.xcconfig"; path = "Target Support Files/Pods-App-Core/Pods-App-Core.debug.xcconfig"; sourceTree = "<group>"; };
 		349B90CD6579F7B8D257E515 /* Pods_App_Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App_Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -416,6 +417,7 @@
 		A51CDBE62B6D21F2009B6D4E /* SegmentConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentConfig.swift; sourceTree = "<group>"; };
 		A53A32342B233DEC005FE38A /* ThemeConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeConfig.swift; sourceTree = "<group>"; };
 		A595689A2B6173DF00ED4F90 /* BranchConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchConfig.swift; sourceTree = "<group>"; };
+		A5CAA1EB2C526901007690D9 /* SecureInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SecureInputView.swift; path = Core/View/Base/SecureInputView.swift; sourceTree = SOURCE_ROOT; };
 		A5F4E7B42B61544A00ACD166 /* BrazeConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrazeConfig.swift; sourceTree = "<group>"; };
 		BA30427D2B20B299009B64B7 /* SocialAuthError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialAuthError.swift; sourceTree = "<group>"; };
 		BA4AFB412B5A7A0900A21367 /* VideoDownloadQualityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoDownloadQualityView.swift; sourceTree = "<group>"; };
@@ -846,6 +848,7 @@
 			children = (
 				9784D47C2BF7761F00AFEFFF /* FullScreenErrorView */,
 				064987882B4D69FE0071642A /* Webview */,
+				A5CAA1EB2C526901007690D9 /* SecureInputView.swift */,
 				E0D586352B314CD3009B4BA7 /* LogistrationBottomView.swift */,
 				02A4833B29B8C57800D33F33 /* DownloadView.swift */,
 				02D800CB29348F460099CF16 /* ImagePicker.swift */,
@@ -943,8 +946,8 @@
 				14DE13DB2BDF83350059168F /* ServerConfig.swift */,
 			);
 			path = ServerConfig;
-            sourceTree = "<group>";
-        };
+			sourceTree = "<group>";
+		};
 		9784D47C2BF7761F00AFEFFF /* FullScreenErrorView */ = {
 			isa = PBXGroup;
 			children = (
@@ -1424,6 +1427,7 @@
 				02CA59842BD7DDBE00D517AA /* DashboardConfig.swift in Sources */,
 				0727877B28D24A1D002E9142 /* HeadersRedirectHandler.swift in Sources */,
 				0236961B28F9A28B00EEF206 /* AuthInteractor.swift in Sources */,
+				A5CAA1EC2C526901007690D9 /* SecureInputView.swift in Sources */,
 				0770DE3028D09793006D8A5D /* EndPointType.swift in Sources */,
 				02935B752BCEE6D600B22F66 /* PrimaryEnrollment.swift in Sources */,
 				020C31C9290AC3F700D6DEA2 /* PickerFields.swift in Sources */,

--- a/Core/Core/View/Base/RegistrationTextField.swift
+++ b/Core/Core/View/Base/RegistrationTextField.swift
@@ -67,7 +67,7 @@ public struct RegistrationTextField: View {
                     .accessibilityIdentifier("\(config.field.name)_textarea")
             } else {
                 if textContentType == .password {
-                    SecureField(placeholder, text: $config.text)
+                    SecureInputView($config.text)
                         .keyboardType(keyboardType)
                         .textContentType(textContentType)
                         .autocapitalization(.none)

--- a/Core/Core/View/Base/SecureInputView.swift
+++ b/Core/Core/View/Base/SecureInputView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Theme
 
 public struct SecureInputView: View {
     
@@ -30,9 +31,9 @@ public struct SecureInputView: View {
                 isSecured.toggle()
             }) {
                 Image(systemName: self.isSecured ? "eye.slash" : "eye")
-                    .accentColor(.gray)
-                    .frame(height: 21)
+                    .accentColor(Theme.Colors.textInputPlaceholderColor)
             }
+            .frame(height: 23)
         }
     }
 }

--- a/Core/Core/View/Base/SecureInputView.swift
+++ b/Core/Core/View/Base/SecureInputView.swift
@@ -1,0 +1,38 @@
+//
+//  SecureInputView.swift
+//  Core
+//
+//  Created by Anton Yarmolenka on 25/07/2024.
+//
+
+import SwiftUI
+
+public struct SecureInputView: View {
+    
+    @Binding private var text: String
+    @State private var isSecured: Bool = true
+    
+    public init(_ text: Binding<String>) {
+        self._text = text
+    }
+    
+    public var body: some View {
+        ZStack(alignment: .trailing) {
+            Group {
+                if isSecured {
+                    SecureField("", text: $text)
+                } else {
+                    TextField("", text: $text)
+                }
+            }.padding(.trailing, 32)
+
+            Button(action: {
+                isSecured.toggle()
+            }) {
+                Image(systemName: self.isSecured ? "eye.slash" : "eye")
+                    .accentColor(.gray)
+                    .frame(height: 21)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR added eye icon for password field
This addressed next issue:
`Password field > The password fields on the Register and Login screen, both, do not show the show password eye icon`

Now password field looks like:
Dark | Light
--- | ---
<img width="200" src="https://github.com/user-attachments/assets/98f47959-3bab-4bf6-9d44-ba0434ad36d7">
<img width="200" src="https://github.com/user-attachments/assets/8ae498ac-08b9-4d4b-919d-dc2c433d9442">
<img width="200" src="https://github.com/user-attachments/assets/f447537b-3c64-4c49-8683-abd753fc6baf">
|
<img width="200" src="https://github.com/user-attachments/assets/579f4c69-2202-4df7-b603-be54119b6cdf">
<img width="200" src="https://github.com/user-attachments/assets/dcd044c4-615d-4bf1-b648-cab88779e8f4">
<img width="200" src="https://github.com/user-attachments/assets/0721844b-d470-4f38-85cb-1f552fd7f7d3">