### PR TITLE
fix: clear cookies by logout

### DIFF
--- a/OpenEdX/Data/AppStorage.swift
+++ b/OpenEdX/Data/AppStorage.swift
@@ -236,6 +236,12 @@ public class AppStorage: CoreStorage, ProfileStorage, WhatsNewStorage, CourseSto
         cookiesDate = nil
         user = nil
         userProfile = nil
+        // delete all cookies
+        if  let cookies = HTTPCookieStorage.shared.cookies {
+            for cookie in cookies {
+                HTTPCookieStorage.shared.deleteCookie(cookie)
+            }
+        }
     }
 
     private let KEY_ACCESS_TOKEN = "accessToken"


### PR DESCRIPTION
This PR fixes issue:
```
Pre-Login Experience > Create account button is not tapable

"when a user register with an already linked socail account then the user gets logged in, after signing out 
and going back to the register screen there is no password field and the user is unable to create an account

Steps to reproduce:
1- Register with an already linked account
2- Sign out
3- Go back to the register screeen 
4- Notice the password field will be missing 
5- Notice the user will be unable to create a new account as the create account button is not tapable "
```

To fix this issue I clear all cookies by logout