### PR TITLE
style: reduce grid spacing

### DIFF
--- a/Dashboard/Dashboard/Presentation/AllCoursesView.swift
+++ b/Dashboard/Dashboard/Presentation/AllCoursesView.swift
@@ -59,7 +59,7 @@ public struct AllCoursesView: View {
                                 .disabled(viewModel.fetchInProgress)
                                 .frameLimit(width: proxy.size.width)
                             if let myEnrollments = viewModel.myEnrollments {
-                                LazyVGrid(columns: columns(), spacing: 15) {
+                                LazyVGrid(columns: columns(), spacing: 0) {
                                     ForEach(
                                         Array(myEnrollments.courses.enumerated()),
                                         id: \.offset
@@ -172,13 +172,13 @@ public struct AllCoursesView: View {
     private func columns() -> [GridItem] {
         isHorizontal || idiom == .pad
         ? [
-            GridItem(.flexible()),
-            GridItem(.flexible()),
-            GridItem(.flexible())
+            GridItem(.flexible(), spacing: 0),
+            GridItem(.flexible(), spacing: 0),
+            GridItem(.flexible(), spacing: 0)
         ]
         : [
-            GridItem(.flexible()),
-            GridItem(.flexible())
+            GridItem(.flexible(), spacing: 0),
+            GridItem(.flexible(), spacing: 0)
         ]
     }
     


### PR DESCRIPTION
This PR is fix for
```
"Learn > Courses > ""View All Courses (149)"" 

The card grid has a bigger padding bewteen each card. They should be 16px"
```

Now the Grid looks like:

iPhone
<p float="left">
<img width="250" src ="https://github.com/user-attachments/assets/061fa051-04b2-4c34-99d8-3eb8b1e15f8e"/>
<img width="450" src ="https://github.com/user-attachments/assets/89ef1051-26e5-4598-8bd1-224a640862c4"/>
</p>

iPad
<p float="left">
<img width="250" src ="https://github.com/user-attachments/assets/12ababea-f2f2-420d-b89e-ccee520e1298"/>
<img width="450" src ="https://github.com/user-attachments/assets/4456f3d7-8504-42d2-8204-1b0a0275b79d"/>
</p>