### PR TITLE
fix: Settings button on profile tab only

### DIFF
--- a/Dashboard/Dashboard/Presentation/ListDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/ListDashboardView.swift
@@ -27,7 +27,6 @@ public struct ListDashboardView: View {
     @StateObject
     private var viewModel: ListDashboardViewModel
     private let router: DashboardRouter
-    private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     
     public init(viewModel: ListDashboardViewModel, router: DashboardRouter) {
         self._viewModel = StateObject(wrappedValue: { viewModel }())
@@ -122,17 +121,6 @@ public struct ListDashboardView: View {
                         .frameLimit(width: proxy.size.width)
                     }.accessibilityAction {}
                 }.padding(.top, 8)
-                HStack {
-                    Spacer()
-                    Button(action: {
-                        router.showSettings()
-                    }, label: {
-                        CoreAssets.settings.swiftUIImage.renderingMode(.template)
-                            .foregroundColor(Theme.Colors.accentColor)
-                    })
-                }
-                .padding(.top, idiom == .pad ? 13 : 5)
-                .padding(.trailing, idiom == .pad ? 20 : 16)
                 
                 // MARK: - Offline mode SnackBar
                 OfflineSnackBarView(connectivity: viewModel.connectivity,

--- a/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
@@ -341,17 +341,6 @@ public struct PrimaryCourseDashboardView<ProgramView: View>: View {
                     }
                 }
                     .frameLimit(width: proxy.size.width)
-                HStack {
-                    Spacer()
-                    Button(action: {
-                        router.showSettings()
-                    }, label: {
-                        CoreAssets.settings.swiftUIImage.renderingMode(.template)
-                            .foregroundColor(Theme.Colors.accentColor)
-                    })
-                }
-                .padding(.top, 8)
-                .offset(x: idiom == .pad ? 1 : 5, y: idiom == .pad ? 4 : -5)
             }
             
             .listRowBackground(Color.clear)

--- a/OpenEdX/View/MainScreenView.swift
+++ b/OpenEdX/View/MainScreenView.swift
@@ -145,14 +145,16 @@ struct MainScreenView: View {
         .navigationTitle(titleBar())
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing, content: {
-                Button(action: {
-                    let router = Container.shared.resolve(ProfileRouter.self)!
-                    router.showSettings()
-                }, label: {
-                    CoreAssets.settings.swiftUIImage.renderingMode(.template)
-                        .foregroundColor(Theme.Colors.accentColor)
-                })
-                .accessibilityIdentifier("edit_profile_button")
+                if viewModel.selection == .profile {
+                    Button(action: {
+                        let router = Container.shared.resolve(ProfileRouter.self)!
+                        router.showSettings()
+                    }, label: {
+                        CoreAssets.settings.swiftUIImage.renderingMode(.template)
+                            .foregroundColor(Theme.Colors.accentColor)
+                    })
+                    .accessibilityIdentifier("edit_profile_button")
+                }
             })
         }
         .onReceive(NotificationCenter.default.publisher(for: .onAppUpgradeAccountSettingsTapped)) { _ in


### PR DESCRIPTION
This PR is fix for
```
Both the Learn tab and the Discover tab have the settings icon at the upper-right hand corner. It should not be there
```

Now we show Settings icon for Profile tab only