### PR TITLE
chore: changes for COPPA compliance removing YOB from profile

### DIFF
--- a/Core/Core/Data/Model/Data_UserProfile.swift
+++ b/Core/Core/Data/Model/Data_UserProfile.swift
@@ -134,6 +134,8 @@ public extension DataLayer.UserProfile {
             spokenLanguage: languageProficiencies?[safe: 0]?.code ?? "",
             shortBiography: bio ?? "",
             isFullProfile: accountPrivacy?.boolValue ?? true,
-            email: email ?? "")
+            email: email ?? "",
+            requiresParentalConsent: requiresParentalConsent ?? false
+        )
     }
 }

--- a/Core/Core/Domain/Model/UserProfile.swift
+++ b/Core/Core/Domain/Model/UserProfile.swift
@@ -18,6 +18,7 @@ public struct UserProfile: Hashable {
     public let shortBiography: String
     public let isFullProfile: Bool
     public let email: String
+    public let requiresParentalConsent: Bool
     
     public init(
         avatarUrl: String,
@@ -29,7 +30,8 @@ public struct UserProfile: Hashable {
         spokenLanguage: String? = nil,
         shortBiography: String,
         isFullProfile: Bool,
-        email: String
+        email: String,
+        requiresParentalConsent: Bool
     ) {
         self.avatarUrl = avatarUrl
         self.name = name
@@ -41,6 +43,7 @@ public struct UserProfile: Hashable {
         self.shortBiography = shortBiography
         self.isFullProfile = isFullProfile
         self.email = email
+        self.requiresParentalConsent = requiresParentalConsent
     }
     
     public init() {
@@ -54,5 +57,6 @@ public struct UserProfile: Hashable {
         self.shortBiography = ""
         self.isFullProfile = true
         self.email = ""
+        self.requiresParentalConsent = false
     }
 }

--- a/Core/Core/View/Base/PickerView.swift
+++ b/Core/Core/View/Base/PickerView.swift
@@ -13,10 +13,16 @@ public struct PickerView: View {
     @ObservedObject
     private var config: FieldConfiguration
     private var router: BaseRouter
+    private var enabled: Bool
     
-    public init(config: FieldConfiguration, router: BaseRouter) {
+    public init(
+        config: FieldConfiguration,
+        router: BaseRouter,
+        enabled: Bool = true
+    ) {
         self.config = config
         self.router = router
+        self.enabled = enabled
     }
     
     public var body: some View {
@@ -52,12 +58,17 @@ public struct PickerView: View {
                         Spacer()
                         Image(systemName: "chevron.down")
                     })
+                    .disabled(!enabled)
                     .accessibilityIdentifier("\(config.field.name)_picker_button")
                 }.padding(.all, 14)
                     .foregroundColor(Theme.Colors.textInputTextColor)
                     .background(
                         Theme.Shapes.textInputShape
-                            .fill(Theme.Colors.textInputBackground)
+                            .fill(
+                                enabled
+                                ? Theme.Colors.textInputBackground
+                                : Theme.Colors.textInputUnfocusedBackground
+                            )
                     )
                     .overlay(
                         Theme.Shapes.textInputShape
@@ -67,6 +78,7 @@ public struct PickerView: View {
                                   : Theme.Colors.irreversibleAlert)
                     )
                     .shake($config.shake)
+                    .opacity(enabled ? 1 : 0.5)
                 Text(config.error == "" ? config.field.instructions
                      : config.error)
                 .font(Theme.Fonts.labelMedium)

--- a/Profile/Profile/Data/ProfileRepository.swift
+++ b/Profile/Profile/Data/ProfileRepository.swift
@@ -157,15 +157,18 @@ public class ProfileRepository: ProfileRepositoryProtocol {
 class ProfileRepositoryMock: ProfileRepositoryProtocol {
     
     public func getUserProfile(username: String) async throws -> Core.UserProfile {
-        return Core.UserProfile(avatarUrl: "",
-                                name: "",
-                                username: "",
-                                dateJoined: Date(),
-                                yearOfBirth: 0,
-                                country: "",
-                                shortBiography: "",
-                                isFullProfile: false,
-                                email: "")
+        return Core.UserProfile(
+            avatarUrl: "",
+            name: "",
+            username: "",
+            dateJoined: Date(),
+            yearOfBirth: 0,
+            country: "",
+            shortBiography: "",
+            isFullProfile: false,
+            email: "",
+            requiresParentalConsent: false
+        )
     }
     
     func getMyProfileOffline() -> Core.UserProfile? {
@@ -184,7 +187,8 @@ class ProfileRepositoryMock: ProfileRepositoryProtocol {
             remains the most successful in history
             """,
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
     }
     
@@ -204,7 +208,8 @@ class ProfileRepositoryMock: ProfileRepositoryProtocol {
             remains the most successful in history
             """,
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
     }
     
@@ -228,7 +233,8 @@ class ProfileRepositoryMock: ProfileRepositoryProtocol {
             country: "USA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
     }
     

--- a/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
+++ b/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
@@ -46,40 +46,70 @@ public struct EditProfileView: View {
                                 .padding(.top, 30)
                                 .overlay(
                                     ZStack {
-                                        Circle().frame(width: 36, height: 36)
-                                            .foregroundColor(Theme.Colors.accentXColor)
-                                        CoreAssets.addPhoto.swiftUIImage.renderingMode(.template)
-                                            .foregroundColor(Theme.Colors.primaryButtonTextColor)
+                                        if !viewModel.userModel.requiresParentalConsent {
+                                            Circle().frame(width: 36, height: 36)
+                                                .foregroundColor(Theme.Colors.accentXColor)
+                                            
+                                            CoreAssets.addPhoto.swiftUIImage.renderingMode(.template)
+                                                .foregroundColor(Theme.Colors.primaryButtonTextColor)
+                                        }
                                     }.offset(x: 36, y: 50)
                                 )
                         })
+                        .disabled(viewModel.userModel.requiresParentalConsent)
                         .accessibilityIdentifier("change_profile_image_button")
                         
                         Text(viewModel.userModel.name)
                             .font(Theme.Fonts.headlineSmall)
                             .accessibilityIdentifier("username_text")
                         
-                        Button(ProfileLocalization.switchTo + " " +
-                               viewModel.profileChanges.profileType.switchToButtonTitle,
-                               action: {
-                            viewModel.switchProfile()
-                        })
-                        .padding(.vertical, 24)
-                        .font(Theme.Fonts.labelLarge)
-                        .accessibilityIdentifier("switch_profile_button")
+                        if !viewModel.userModel.requiresParentalConsent {
+                            Button(ProfileLocalization.switchTo + " " +
+                                   viewModel.profileChanges.profileType.switchToButtonTitle,
+                                   action: {
+                                viewModel.switchProfile()
+                            })
+                            .padding(.vertical, 24)
+                            .font(Theme.Fonts.labelLarge)
+                            .accessibilityIdentifier("switch_profile_button")
+                        }
+                        
+                        HStack(alignment: .center) {
+                            let infoMessage = viewModel.userModel.requiresParentalConsent
+                            ? ProfileLocalization.Edit.limitedProfileRequireConsentInfo
+                            : ProfileLocalization.Edit.limitedProfileInfo
+                            if viewModel.userModel.requiresParentalConsent {
+                                Image(systemName: "eye.slash")
+                                    .accentColor(Theme.Colors.textSecondaryLight)
+                            }
+                            
+                            Text(infoMessage)
+                                .font(Theme.Fonts.bodyMedium)
+                                .foregroundColor(Theme.Colors.textSecondaryLight)
+                                .multilineTextAlignment(.center)
+                        }
+                        .padding(.top, viewModel.userModel.requiresParentalConsent ? 10 : 0)
                         
                         Group {
-                            PickerView(
-                                config: viewModel.yearsConfiguration,
-                                router: viewModel.router
-                            )
-                            if viewModel.isEditable {
+//                            PickerView(
+//                                config: viewModel.yearsConfiguration,
+//                                router: viewModel.router
+//                            )
+//                            if viewModel.isEditable {
+                            
                                 VStack(alignment: .leading) {
-                                    PickerView(config: viewModel.countriesConfiguration,
-                                               router: viewModel.router)
                                     
-                                    PickerView(config: viewModel.spokenLanguageConfiguration,
-                                               router: viewModel.router)
+                                    PickerView(
+                                        config: viewModel.countriesConfiguration,
+                                        router: viewModel.router,
+                                        enabled: viewModel.isEditable
+                                    )
+                                    
+                                    PickerView(
+                                        config: viewModel.spokenLanguageConfiguration,
+                                        router: viewModel.router,
+                                        enabled: viewModel.isEditable
+                                    )
                                     
                                     Text(ProfileLocalization.Edit.Fields.aboutMe)
                                         .font(Theme.Fonts.titleMedium)
@@ -91,9 +121,14 @@ public struct EditProfileView: View {
                                         .padding(.vertical, 4)
                                         .frame(height: 200)
                                         .hideScrollContentBackground()
+                                        .disabled(!viewModel.isEditable)
                                         .background(
                                             Theme.Shapes.textInputShape
-                                                .fill(Theme.Colors.textInputBackground)
+                                                .fill(
+                                                    viewModel.isEditable
+                                                    ? Theme.Colors.textInputBackground
+                                                    : Theme.Colors.textInputUnfocusedBackground
+                                                )
                                         )
                                         .overlay(
                                             Theme.Shapes.textInputShape
@@ -102,9 +137,10 @@ public struct EditProfileView: View {
                                                     Theme.Colors.textInputStroke
                                                 )
                                         )
+                                        .opacity(viewModel.isEditable ? 1 : 0.5)
                                         .accessibilityIdentifier("short_bio_textarea")
                                 }
-                            }
+//                            }
                         }
                         .onReceive(viewModel.yearsConfiguration.$text
                             .combineLatest(viewModel.countriesConfiguration.$text,
@@ -255,7 +291,8 @@ struct EditProfileView_Previews: PreviewProvider {
             country: "Ukraine",
             shortBiography: "",
             isFullProfile: true,
-            email: "peter@example.org"
+            email: "peter@example.org",
+            requiresParentalConsent: false
         )
         
         EditProfileView(

--- a/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
+++ b/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
@@ -71,6 +71,7 @@ public struct EditProfileView: View {
                             })
                             .padding(.vertical, 24)
                             .font(Theme.Fonts.labelLarge)
+                            .foregroundColor(Theme.Colors.infoColor)
                             .accessibilityIdentifier("switch_profile_button")
                         }
                         

--- a/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
+++ b/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
@@ -79,8 +79,8 @@ public struct EditProfileView: View {
                             ? ProfileLocalization.Edit.limitedProfileRequireConsentInfo
                             : ProfileLocalization.Edit.limitedProfileInfo
                             if viewModel.userModel.requiresParentalConsent {
-                                Image(systemName: "eye.slash")
-                                    .accentColor(Theme.Colors.textSecondaryLight)
+                                Image(systemName: "eye.slash").renderingMode(.template)
+                                    .foregroundColor(Theme.Colors.textSecondaryLight)
                             }
                             
                             Text(infoMessage)
@@ -257,7 +257,7 @@ public struct EditProfileView: View {
                         }
                     }, label: {
                         HStack(spacing: 2) {
-                            CoreAssets.done.swiftUIImage.renderingMode(.template)
+                            CoreAssets.done.swiftUIImage
                                 .foregroundColor(Theme.Colors.accentXColor)
                             Text(CoreLocalization.done)
                                 .font(Theme.Fonts.labelLarge)

--- a/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
+++ b/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
@@ -248,25 +248,28 @@ public struct EditProfileView: View {
                         .offset(x: -8, y: -1.5)
                     }
                 )
+                
                 ToolbarItem(placement: .navigationBarTrailing, content: {
-                    Button(action: {
-                        if viewModel.isChanged {
-                            Task {
-                                viewModel.trackProfileEditDoneClicked()
-                                await viewModel.saveProfileUpdates()
+                    if !viewModel.userModel.requiresParentalConsent {
+                        Button(action: {
+                            if viewModel.isChanged {
+                                Task {
+                                    viewModel.trackProfileEditDoneClicked()
+                                    await viewModel.saveProfileUpdates()
+                                }
                             }
-                        }
-                    }, label: {
-                        HStack(spacing: 2) {
-                            CoreAssets.done.swiftUIImage
-                                .foregroundColor(Theme.Colors.accentXColor)
-                            Text(CoreLocalization.done)
-                                .font(Theme.Fonts.labelLarge)
-                                .foregroundColor(Theme.Colors.accentXColor)
-                        }
-                    })
-                    .opacity(viewModel.isChanged ? 1 : 0.3)
-                    .accessibilityIdentifier("done_button")
+                        }, label: {
+                            HStack(spacing: 2) {
+                                CoreAssets.done.swiftUIImage
+                                    .foregroundColor(Theme.Colors.accentXColor)
+                                Text(CoreLocalization.done)
+                                    .font(Theme.Fonts.labelLarge)
+                                    .foregroundColor(Theme.Colors.accentXColor)
+                            }
+                        })
+                        .opacity(viewModel.isChanged ? 1 : 0.3)
+                        .accessibilityIdentifier("done_button")
+                    }
                 })
             }
             .background(

--- a/Profile/Profile/SwiftGen/Strings.swift
+++ b/Profile/Profile/SwiftGen/Strings.swift
@@ -214,6 +214,10 @@ public enum ProfileLocalization {
     public static let deleteAccount = ProfileLocalization.tr("Localizable", "EDIT.DELETE_ACCOUNT", fallback: "Delete Account")
     /// A limited profile only shares your username and profile photo.
     public static let limitedProfileDescription = ProfileLocalization.tr("Localizable", "EDIT.LIMITED_PROFILE_DESCRIPTION", fallback: "A limited profile only shares your username and profile photo.")
+    /// A limited profile only shares your username and photo
+    public static let limitedProfileInfo = ProfileLocalization.tr("Localizable", "EDIT.LIMITED_PROFILE_INFO", fallback: "A limited profile only shares your username and photo")
+    /// Your profile information is only visible to you. Only your username is visible to others.
+    public static let limitedProfileRequireConsentInfo = ProfileLocalization.tr("Localizable", "EDIT.LIMITED_PROFILE_REQUIRE_CONSENT_INFO", fallback: "Your profile information is only visible to you. Only your username is visible to others.")
     /// You must be over 13 years old to have a profile with full access to information.
     public static let tooYongUser = ProfileLocalization.tr("Localizable", "EDIT.TOO_YONG_USER", fallback: "You must be over 13 years old to have a profile with full access to information.")
     public enum BottomSheet {

--- a/Profile/Profile/en.lproj/Localizable.strings
+++ b/Profile/Profile/en.lproj/Localizable.strings
@@ -42,6 +42,8 @@
 "EDIT.TOO_YONG_USER" = "You must be over 13 years old to have a profile with full access to information.";
 "EDIT.LIMITED_PROFILE_DESCRIPTION" = "A limited profile only shares your username and profile photo.";
 "EDIT.DELETE_ACCOUNT" = "Delete Account";
+"EDIT.LIMITED_PROFILE_INFO" = "A limited profile only shares your username and photo";
+"EDIT.LIMITED_PROFILE_REQUIRE_CONSENT_INFO" = "Your profile information is only visible to you. Only your username is visible to others.";
 
 "EDIT.FIELDS.YEAR_OF_BIRTH" = "Year of birth";
 "EDIT.FIELDS.LOCATION" = "Location";

--- a/Profile/Profile/uk.lproj/Localizable.strings
+++ b/Profile/Profile/uk.lproj/Localizable.strings
@@ -41,6 +41,8 @@
 "EDIT.TOO_YONG_USER" = "Вам має бути більше 13 років, щоб мати профіль із повним доступом до інформації.";
 "EDIT.LIMITED_PROFILE_DESCRIPTION" = "В обмеженому профілі доступні лише ваше ім’я користувача.";
 "EDIT.DELETE_ACCOUNT" = "Видалити акаунт";
+"EDIT.LIMITED_PROFILE_INFO" = "A limited profile only shares your username and photo";
+"EDIT.LIMITED_PROFILE_REQUIRE_CONSENT_INFO" = "Your profile information is only visible to you. Only your username is visible to others.";
 
 "EDIT.FIELDS.YEAR_OF_BIRTH" = "Рік народження:";
 "EDIT.FIELDS.LOCATION" = "Країна";

--- a/Profile/ProfileTests/Presentation/EditProfile/EditProfileViewModelTests.swift
+++ b/Profile/ProfileTests/Presentation/EditProfile/EditProfileViewModelTests.swift
@@ -29,7 +29,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -67,7 +68,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -105,7 +107,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -138,7 +141,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -171,7 +175,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -204,7 +209,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -237,7 +243,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -270,7 +277,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -303,7 +311,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -340,7 +349,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -377,7 +387,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -413,7 +424,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -449,7 +461,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -498,7 +511,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -542,7 +556,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -599,7 +614,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -654,7 +670,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -693,7 +710,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -726,7 +744,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -758,7 +777,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: true,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         let languages = [
@@ -796,7 +816,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))
@@ -828,7 +849,8 @@ final class EditProfileViewModelTests: XCTestCase {
             spokenLanguage: "UA",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getSpokenLanguages(willReturn: []))

--- a/Profile/ProfileTests/Presentation/Profile/ProfileViewModelTests.swift
+++ b/Profile/ProfileTests/Presentation/Profile/ProfileViewModelTests.swift
@@ -31,7 +31,8 @@ final class ProfileViewModelTests: XCTestCase {
             country: "Ua",
             shortBiography: "Bio",
             isFullProfile: false, 
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(interactor, .getUserProfile(username: .value("Steve"), willReturn: user))
@@ -108,7 +109,8 @@ final class ProfileViewModelTests: XCTestCase {
             country: "Ua",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(connectivity, .isInternetAvaliable(getter: true))
@@ -147,7 +149,8 @@ final class ProfileViewModelTests: XCTestCase {
             country: "Ua",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         Given(connectivity, .isInternetAvaliable(getter: false))
@@ -185,7 +188,8 @@ final class ProfileViewModelTests: XCTestCase {
             country: "Ua",
             shortBiography: "Bio",
             isFullProfile: false,
-            email: ""
+            email: "",
+            requiresParentalConsent: false
         )
         
         let noInternetError = AFError.sessionInvalidated(error: URLError(.notConnectedToInternet))


### PR DESCRIPTION
This PR addresses the following requirement:
```
1. COPPA compliance isn't being followed, in the profile section I can add/update my year of birth and switch between limited and full profile

2. "Profile > Edit profile > ""Switch to full profile"" and ""Switch to limited profile""

Recommend putting these in our info-500 to distinguish it from the header"
```

Note: Instead of removing the code, I've commented the code, because most MVP we might be moving these changes behind a feature flag.

We currently don't have specific design guidelines for this request. So the changes are approved by @moiz994


https://github.com/user-attachments/assets/d7b4e5b6-27e0-46a2-af3e-bd869bf13011

