### PR TITLE
style: swap colors out for transcript highlighting

### DIFF
--- a/Course/Course/Presentation/Video/SubtitlesView.swift
+++ b/Course/Course/Presentation/Video/SubtitlesView.swift
@@ -75,8 +75,8 @@ public struct SubtitlesView: View {
                                                   : Theme.Fonts.bodyMedium)
                                             .multilineTextAlignment(.leading)
                                             .foregroundColor(subtitle.fromTo.contains(Date(milliseconds: currentTime))
-                                                             ? Theme.Colors.textPrimary
-                                                             : Theme.Colors.accentButtonColor)
+                                                             ? Theme.Colors.accentButtonColor
+                                                             : Theme.Colors.textPrimary)
                                             
                                             .onChange(of: currentTime, perform: { _ in
                                                 if subtitle.fromTo.contains(Date(milliseconds: currentTime)) {


### PR DESCRIPTION
This is a small fix to change the highlighting colour for the transcript

Now it looks like:
<p float="left">
<img width="250" src="https://github.com/user-attachments/assets/ed08b849-b8c2-46c1-8dcb-d840cfd40bf6">
<img width="250" src="https://github.com/user-attachments/assets/3401f7be-bab8-4069-8230-a86d772d82a6">
</p>