### PR TITLE
chore: Fix outdated course dates alert title truncation issue

### DIFF
--- a/Core/Core/View/Base/AlertView.swift
+++ b/Core/Core/View/Base/AlertView.swift
@@ -182,6 +182,7 @@ public struct AlertView: View {
                     .font(Theme.Fonts.titleLarge)
                     .foregroundColor(Theme.Colors.textPrimary)
                     .padding(.horizontal, 40)
+                    .fixedSize(horizontal: false, vertical: true)
                 Text(alertMessage)
                     .font(Theme.Fonts.bodyMedium)
                     .foregroundColor(Theme.Colors.textPrimary)


### PR DESCRIPTION
On iOS 16, outdated course dates alert titles were being truncated. This issue was resolved and was functioning correctly on iOS 17. The problem with iOS 16 has now been fixed in this PR.

| **Before** | **After** |
|----------|----------|
| ![Simulator Screenshot - iPad (10th generation) - 2024-07-29 at 18 56 45](https://github.com/user-attachments/assets/d7c71b6d-254d-46f9-a6f1-b31705cb226e) | ![Simulator Screenshot - iPad (10th generation) - 2024-07-29 at 18 57 45](https://github.com/user-attachments/assets/86093f6e-cf6d-449f-aed5-580971daa8c8) |