### PR TITLE
feat: banner when register with already linked social account

### DIFF
--- a/Authorization/Authorization/Presentation/Registration/SignUpViewModel.swift
+++ b/Authorization/Authorization/Presentation/Registration/SignUpViewModel.swift
@@ -193,7 +193,13 @@ public class SignUpViewModel: ObservableObject {
             analytics.userLogin(method: authMethod)
             isShowProgress = false
             router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen)
-            NotificationCenter.default.post(name: .userAuthorized, object: nil)
+            NotificationCenter.default.post(
+                name: .userAuthorized,
+                object: [
+                    "authMethod": authMethod,
+                    "showSocialRegisterBanner": true
+                    ]
+            )
         } catch {
             update(fullName: response.name, email: response.email)
             self.externalToken = response.token

--- a/Core/Core/SwiftGen/Strings.swift
+++ b/Core/Core/SwiftGen/Strings.swift
@@ -300,6 +300,10 @@ public enum CoreLocalization {
     public static let profile = CoreLocalization.tr("Localizable", "MAINSCREEN.PROFILE", fallback: "Profile")
     /// Programs
     public static let programs = CoreLocalization.tr("Localizable", "MAINSCREEN.PROGRAMS", fallback: "Programs")
+    /// You already set up an %@ account with your %@ account. You have been logged in with that account.
+    public static func socialRegisterBanner(_ p1: Any, _ p2: Any) -> String {
+      return CoreLocalization.tr("Localizable", "MAINSCREEN.SOCIAL_REGISTER_BANNER", String(describing: p1), String(describing: p2), fallback: "You already set up an %@ account with your %@ account. You have been logged in with that account.")
+    }
   }
   public enum NoInternet {
     /// Dismiss

--- a/Core/Core/en.lproj/Localizable.strings
+++ b/Core/Core/en.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "MAINSCREEN.PROGRAMS" = "Programs";
 "MAINSCREEN.PROFILE" = "Profile";
 "MAINSCREEN.LEARN" = "Learn";
+"MAINSCREEN.SOCIAL_REGISTER_BANNER" = "You already set up an %@ account with your %@ account. You have been logged in with that account.";
 
 "VIEW.SNACKBAR.TRY_AGAIN_BTN" = "Try Again";
 

--- a/Core/Core/uk.lproj/Localizable.strings
+++ b/Core/Core/uk.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "MAINSCREEN.PROGRAMS" = "Програми";
 "MAINSCREEN.PROFILE" = "Профіль";
 "MAINSCREEN.LEARN" = "Навчання";
+"MAINSCREEN.SOCIAL_REGISTER_BANNER" = "You already set up an %@ account with your %@ account. You have been logged in with that account.";
 
 "VIEW.SNACKBAR.TRY_AGAIN_BTN" = "Спробувати ще";
 

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -41,7 +41,12 @@ public class Router: AuthorizationRouter,
         self.navigationController = navigationController
         self.container = container
         
-        NotificationCenter.default.addObserver(self, selector: #selector(orientationChanged), name: UIDevice.orientationDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(orientationChanged),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
     }
 
     public func backToRoot(animated: Bool) {
@@ -516,7 +521,6 @@ public class Router: AuthorizationRouter,
         courseStructure: CourseStructure,
         blockLink: String) {
             var courseBlock: CourseBlock?
-            var courseName: String?
             var chapterPosition: Int?
             var sequentialPosition: Int?
             var verticalPosition: Int?
@@ -527,7 +531,6 @@ public class Router: AuthorizationRouter,
                         vertical.childs.forEach { block in
                             if block.id == componentID {
                                 courseBlock = block
-                                courseName = sequential.displayName
                                 chapterPosition = chapterIndex
                                 sequentialPosition = sequentialIndex
                                 verticalPosition = verticalIndex
@@ -548,7 +551,8 @@ public class Router: AuthorizationRouter,
                         verticalIndex: verticalPosition ?? 0,
                         chapters: courseStructure.childs,
                         chapterIndex: chapterPosition ?? 0,
-                        sequentialIndex: sequentialPosition ?? 0)
+                        sequentialIndex: sequentialPosition ?? 0
+                    )
                 }
             } else if !blockLink.isEmpty, let blockURL = URL(string: blockLink) {
                 DispatchQueue.main.async { [weak self] in

--- a/OpenEdX/View/MainScreenView.swift
+++ b/OpenEdX/View/MainScreenView.swift
@@ -48,6 +48,7 @@ struct MainScreenView: View {
                     if updateAvailable {
                         UpdateNotificationView(config: viewModel.config)
                     }
+                    registerBanner
                 }
                 .tabItem {
                     CoreAssets.dashboard.swiftUIImage.renderingMode(.template)
@@ -55,6 +56,7 @@ struct MainScreenView: View {
                 }
                 .tag(MainTab.dashboard)
                 .accessibilityIdentifier("dashboard_tabitem")
+                .animation(.easeInOut, value: viewModel.showRegisterBanner)
                 if viewModel.config.program.enabled {
                     ZStack {
                         if viewModel.config.program.type == .webview {
@@ -90,6 +92,7 @@ struct MainScreenView: View {
                     if updateAvailable {
                         UpdateNotificationView(config: viewModel.config)
                     }
+                    registerBanner
                 }
                 .tabItem {
                     CoreAssets.learn.swiftUIImage.renderingMode(.template)
@@ -97,6 +100,7 @@ struct MainScreenView: View {
                 }
                 .tag(MainTab.dashboard)
                 .accessibilityIdentifier("dashboard_tabitem")
+                .animation(.easeInOut, value: viewModel.showRegisterBanner)
             }
             
             if viewModel.config.discovery.enabled {
@@ -185,10 +189,28 @@ struct MainScreenView: View {
             Task {
                 await viewModel.prefetchDataForOffline()
             }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                viewModel.checkIfNeedToShowRegisterBanner()
+            }
         }
         .accentColor(Theme.Colors.accentXColor)
         .introspect(.viewController, on: .iOS(.v15)) { controller in
             controller.navigationController?.setNavigationBarHidden(true, animated: false)
+        }
+    }
+    
+    @ViewBuilder
+    private var registerBanner: some View {
+        if viewModel.showRegisterBanner {
+            VStack {
+                SnackBarView(message: viewModel.registerBannerText, bgColor: Theme.Colors.accentColor)
+                Spacer()
+            }.transition(.move(edge: .top))
+                .onAppear {
+                    doAfter(Theme.Timeout.snackbarMessageLongTimeout) {
+                        viewModel.registerBannerWasShowed()
+                    }
+                }
         }
     }
     

--- a/OpenEdX/View/MainScreenView.swift
+++ b/OpenEdX/View/MainScreenView.swift
@@ -203,7 +203,11 @@ struct MainScreenView: View {
     private var registerBanner: some View {
         if viewModel.showRegisterBanner {
             VStack {
-                SnackBarView(message: viewModel.registerBannerText, bgColor: Theme.Colors.accentColor)
+                SnackBarView(
+                    message: viewModel.registerBannerText,
+                    textColor: Theme.Colors.primaryButtonTextColor,
+                    bgColor: Theme.Colors.accentColor
+                )
                 Spacer()
             }.transition(.move(edge: .top))
                 .onAppear {

--- a/OpenEdX/View/MainScreenViewModel.swift
+++ b/OpenEdX/View/MainScreenViewModel.swift
@@ -8,6 +8,8 @@
 import Foundation
 import Core
 import Profile
+import Combine
+import Authorization
 
 final class MainScreenViewModel: ObservableObject {
 
@@ -17,6 +19,11 @@ final class MainScreenViewModel: ObservableObject {
     var sourceScreen: LogistrationSourceScreen
 
     @Published var selection: MainTab = .dashboard
+    @Published var showRegisterBanner: Bool = false
+
+    private var shouldShowRegisterBanner: Bool = false
+    private var authMethod: AuthMethod?
+    private var cancellations: [AnyCancellable] = []
 
     init(analytics: MainScreenAnalytics,
          config: ConfigProtocol,
@@ -27,6 +34,22 @@ final class MainScreenViewModel: ObservableObject {
         self.config = config
         self.profileInteractor = profileInteractor
         self.sourceScreen = sourceScreen
+        addObservers()
+    }
+    
+    private func addObservers() {
+        NotificationCenter.default
+            .publisher(for: .userAuthorized)
+            .sink { [weak self] object in
+                guard let self,
+                      let dict = object.object as? [String: Any],
+                      let authMethod = dict["authMethod"] as? AuthMethod,
+                      let shouldShowBanner = dict["showSocialRegisterBanner"] as? Bool
+                else { return }
+                self.shouldShowRegisterBanner = shouldShowBanner
+                self.authMethod = authMethod
+            }
+            .store(in: &cancellations)
     }
 
     public func select(tab: MainTab) {
@@ -44,6 +67,23 @@ final class MainScreenViewModel: ObservableObject {
     }
     func trackMainProfileTabClicked() {
         analytics.mainProfileTabClicked()
+    }
+
+    public func checkIfNeedToShowRegisterBanner() {
+        if shouldShowRegisterBanner && !registerBannerText.isEmpty {
+            showRegisterBanner = true
+        }
+    }
+    public func registerBannerWasShowed() {
+        shouldShowRegisterBanner = false
+        showRegisterBanner = false
+    }
+    public var registerBannerText: String {
+        guard !config.platformName.isEmpty,
+              case .socailAuth(let socialMethod) = authMethod,
+              !socialMethod.rawValue.isEmpty
+        else { return "" }
+        return CoreLocalization.Mainscreen.socialRegisterBanner(config.platformName, socialMethod.rawValue.capitalized)
     }
 
     @MainActor


### PR DESCRIPTION
This PR is adding banner on main screen for case when user does register with social login what is linked already 
from BugBash doc:
```
Register Screen > On regestring with an already linked account the banner for linked accounts is not appearing 
```
It is showing as:

https://github.com/user-attachments/assets/76a051c2-a572-415e-8f08-85b693df7504

Color for light and dark:
<p float="left">
<img width="250" src="https://github.com/user-attachments/assets/a56460e4-9b46-4fdd-a135-6e63ade0dbd4">
<img width="250" src="https://github.com/user-attachments/assets/c724f7c6-baef-49a4-84f7-5daf23741446">
</p>