### PR TITLE
fix: shift due dates banner overlap

### DIFF
--- a/Course/Course/Presentation/Outline/CourseOutlineView.swift
+++ b/Course/Course/Presentation/Outline/CourseOutlineView.swift
@@ -82,7 +82,8 @@ public struct CourseOutlineView: View {
                                 if let courseDeadlineInfo = viewModel.courseDeadlineInfo,
                                    courseDeadlineInfo.datesBannerInfo.status == .resetDatesBanner,
                                    !courseDeadlineInfo.hasEnded,
-                                   !isVideo {
+                                   !isVideo,
+                                   !viewModel.isShowProgress {
                                     DatesStatusInfoView(
                                         datesBannerInfo: courseDeadlineInfo.datesBannerInfo,
                                         courseID: courseID,

--- a/OpenEdX/View/MainScreenView.swift
+++ b/OpenEdX/View/MainScreenView.swift
@@ -188,7 +188,9 @@ struct MainScreenView: View {
         }
         .accentColor(Theme.Colors.accentXColor)
         .introspect(.viewController, on: .iOS(.v15)) { controller in
-            controller.navigationController?.setNavigationBarHidden(true, animated: false)
+            if viewModel.selection != .profile {
+                controller.navigationController?.setNavigationBarHidden(true, animated: false)
+            }
         }
     }
     


### PR DESCRIPTION
[iOS] The loading indicator overlaps “Shift due dates” button #419

How it works now: 

https://github.com/user-attachments/assets/26a8c2eb-599f-48c4-8620-aa5cc0e318bf


Also that PR contains fix for profile icon issue on profile tab on iOS 15 it disappears when you go to settings and then go back to profile
