### PR TITLE
fix: Full screen error fix if access expires

### DIFF
--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -261,8 +261,10 @@ public class CourseContainerViewModel: BaseCourseViewModel {
             isShowProgress = false
             isShowRefresh = false
             shouldShowUpgradeButton = false
-            courseStructure = nil
-            courseVideosStructure = nil
+            if courseStructure?.coursewareAccessDetails?.coursewareAccess?.errorCode == .unknown {
+                courseStructure = nil
+                courseVideosStructure = nil
+            }
         }
     }
     


### PR DESCRIPTION
This PR includes a fix to prevent additional full-screen errors when a course access expiration error is already present.

It will set priorities. If there are any coursewareAccess errors, prioritize those and ignore other types of errors. If coursewareAccess is `.unknown`, display any other types of errors.