### PR TITLE
chore: size in GB or MB

### DIFF
--- a/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarView.swift
+++ b/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarView.swift
@@ -114,7 +114,7 @@ struct CourseVideoDownloadBarView: View {
                                 .accessibilityIdentifier("remaining_videos_text")
                         }
                         if let totalSize = viewModel.totalSize {
-                            let text = ", \(totalSize)MB \(CourseLocalization.Download.total)"
+                            let text = ", \(totalSize) \(CourseLocalization.Download.total)"
                             Text(text)
                                 .accessibilityElement(children: .ignore)
                                 .accessibilityLabel(text)

--- a/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarViewModel.swift
+++ b/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarViewModel.swift
@@ -90,9 +90,9 @@ final class CourseVideoDownloadBarViewModel: ObservableObject {
         if isOn {
             let size =  mb - calculateSize(value: mb, percentage: progress * 100)
             if size == 0 {
-                return String(format: "%.2f", mb)
+                return sizeInMbOrGb(size: mb)
             }
-            return String(format: "%.2f", size)
+            return sizeInMbOrGb(size: size)
         }
 
         let size = blockToMB(
@@ -103,7 +103,15 @@ final class CourseVideoDownloadBarViewModel: ObservableObject {
             downloadQuality: downloadQuality
         )
 
-        return String(format: "%.2f", size)
+        return sizeInMbOrGb(size: size)
+    }
+
+    private func sizeInMbOrGb(size: Double) -> String {
+        if size >= 1024.0 {
+            return String(format: "%.2fGB", size / 1024.0)
+        } else {
+            return String(format: "%.2fMB", size)
+        }
     }
 
     init(


### PR DESCRIPTION
This PR fixes an issue with displaying the remaining size for small device screens
In doc: `"MB" are hidden on a device with a small screen (only if a large number of files are available)`

https://github.com/user-attachments/assets/1b624e2f-1404-41fe-8c46-f869638a81ca

After fix it shows in GB if size > 1024 MB
<p float="left">
<img width="250" src="https://github.com/user-attachments/assets/370c0931-85b4-4953-91ed-838a2536ba7c">
<img width="250" src="https://github.com/user-attachments/assets/457f6731-616b-4247-bf6b-52469cde69f0">
</p>