### PR TITLE
style: use textSecondary for message

### DIFF
--- a/Core/Core/View/Base/AppReview/AppReviewView.swift
+++ b/Core/Core/View/Base/AppReview/AppReviewView.swift
@@ -48,6 +48,7 @@ public struct AppReviewView: View {
                     }
                     Text(viewModel.state.title)
                         .font(Theme.Fonts.titleMedium)
+                        .foregroundColor(Theme.Colors.textPrimary)
                     Text(viewModel.state.description)
                         .font(Theme.Fonts.titleSmall)
                         .foregroundColor(Theme.Colors.textSecondary)

--- a/Core/Core/View/Base/AppReview/AppReviewView.swift
+++ b/Core/Core/View/Base/AppReview/AppReviewView.swift
@@ -50,7 +50,7 @@ public struct AppReviewView: View {
                         .font(Theme.Fonts.titleMedium)
                     Text(viewModel.state.description)
                         .font(Theme.Fonts.titleSmall)
-                        .foregroundColor(Theme.Colors.avatarStroke)
+                        .foregroundColor(Theme.Colors.textSecondary)
                         .multilineTextAlignment(.center)
                     switch viewModel.state {
                     case .vote:


### PR DESCRIPTION
PR fixes issue with too light color for App Review Message (doc `Native Videos > Rating the app pop-up shows a very light text` issue)
<img width="250" src="https://github.com/user-attachments/assets/e98bd54c-78d4-4d04-8c6e-328e16ffc7bb">

Now we use `textSecondary` for Message and `textPrimary` for Title and the View looks like:
<p float="left">
<img width="250" src="https://github.com/user-attachments/assets/9159fb64-6a16-41b5-b1eb-5aa57d3d423d">
<img width="250" src="https://github.com/user-attachments/assets/b7c843d3-5e74-44c9-a183-f420702df71e">
</p>