### PR TITLE
fix: two TabBars in course dashboard screen for iOS 15

### DIFF
--- a/Core/Core/Data/Model/Data_UserProfile.swift
+++ b/Core/Core/Data/Model/Data_UserProfile.swift
@@ -69,12 +69,13 @@ public extension DataLayer {
 // MARK: - AccountPrivacy
 public enum AccountPrivacy: String, Codable {
     case privateAccess = "private"
+    case privateAccessBig = "PRIVATE"
     case allUsers = "all_users"
     case allUsersBig = "ALL_USERS"
     
     public var boolValue: Bool {
         switch self {
-        case .privateAccess:
+        case .privateAccess, .privateAccessBig:
             return false
         case .allUsers, .allUsersBig:
             return true

--- a/Core/Core/Extensions/ViewExtension.swift
+++ b/Core/Core/Extensions/ViewExtension.swift
@@ -179,15 +179,15 @@ public extension View {
         }
     }
     
-    func hideNavigationBar() -> some View {
+    func hideNavigationBar(_ isHidden: Bool = true) -> some View {
         if #available(iOS 16.0, *) {
-            return self.navigationBarHidden(true)
+            return self.navigationBarHidden(isHidden)
         } else {
             return self.introspect(
                 .navigationView(style: .stack),
                 on: .iOS(.v15...),
                 scope: .ancestor) {
-                    $0.isNavigationBarHidden = true
+                    $0.isNavigationBarHidden = isHidden
                 }
         }
     }

--- a/Core/Core/Extensions/ViewExtension.swift
+++ b/Core/Core/Extensions/ViewExtension.swift
@@ -183,12 +183,14 @@ public extension View {
         if #available(iOS 16.0, *) {
             return self.navigationBarHidden(isHidden)
         } else {
-            return self.introspect(
-                .navigationView(style: .stack),
-                on: .iOS(.v15...),
-                scope: .ancestor) {
-                    $0.isNavigationBarHidden = isHidden
-                }
+            return self
+                .navigationBarHidden(isHidden)
+                .introspect(
+                    .navigationView(style: .stack),
+                    on: .iOS(.v15...),
+                    scope: .ancestor) {
+                        $0.isNavigationBarHidden = isHidden
+                    }
         }
     }
 

--- a/Core/Core/View/Base/VideoDownloadQualityView.swift
+++ b/Core/Core/View/Base/VideoDownloadQualityView.swift
@@ -136,7 +136,7 @@ public struct VideoDownloadQualityView: View {
                 }
             }
         }
-        .navigationBarHidden(!isModal)
+        .hideNavigationBar(!isModal)
         .navigationBarBackButtonHidden(!isModal)
         .navigationTitle(CoreLocalization.Settings.videoDownloadQualityTitle)
         .ignoresSafeArea(.all, edges: .horizontal)

--- a/Core/Core/View/Base/WebBrowser.swift
+++ b/Core/Core/View/Base/WebBrowser.swift
@@ -42,7 +42,7 @@ public struct WebBrowser: View {
                 }
             }
             .navigationBarTitle(Text(""))
-            .navigationBarHidden(true)
+            .hideNavigationBar(true)
             .ignoresSafeArea()
         }
     }

--- a/Course/Course/Presentation/Container/CourseContainerView.swift
+++ b/Course/Course/Presentation/Container/CourseContainerView.swift
@@ -237,6 +237,7 @@ public struct CourseContainerView: View {
                                 viewHeight: $viewHeight,
                                 dateTabIndex: CourseTab.dates.rawValue
                             )
+                            .padding(.bottom, 1)
                             .tabItem {
                                 tab.image
                                 Text(tab.title)
@@ -255,6 +256,7 @@ public struct CourseContainerView: View {
                                 viewHeight: $viewHeight,
                                 dateTabIndex: CourseTab.dates.rawValue
                             )
+                            .padding(.bottom, 1)
                             .tabItem {
                                 tab.image
                                 Text(tab.title)
@@ -271,6 +273,7 @@ public struct CourseContainerView: View {
                                 shouldShowUpgradeButton: $viewModel.shouldShowUpgradeButton,
                                 shouldHideMenuBar: $viewModel.shouldHideMenuBar
                             )
+                            .padding(.bottom, 1)
                             .tabItem {
                                 tab.image
                                 Text(tab.title)
@@ -289,6 +292,7 @@ public struct CourseContainerView: View {
                                 shouldShowUpgradeButton: $viewModel.shouldShowUpgradeButton,
                                 shouldHideMenuBar: $viewModel.shouldHideMenuBar
                             )
+                            .padding(.bottom, 1)
                             .tabItem {
                                 tab.image
                                 Text(tab.title)
@@ -305,6 +309,7 @@ public struct CourseContainerView: View {
                                 shouldShowUpgradeButton: $viewModel.shouldShowUpgradeButton,
                                 shouldHideMenuBar: $viewModel.shouldHideMenuBar
                             )
+                            .padding(.bottom, 1)
                             .tabItem {
                                 tab.image
                                 Text(tab.title)

--- a/Course/Course/Presentation/Container/CourseContainerView.swift
+++ b/Course/Course/Presentation/Container/CourseContainerView.swift
@@ -323,6 +323,7 @@ public struct CourseContainerView: View {
         .introspect(.viewController, on: .iOS(.v15), customize: { controller in
             controller.navigationController?.setNavigationBarHidden(true, animated: false)
         })
+        .accentColor(Theme.Colors.accentXColor)
         .onFirstAppear {
             Task {
                 await viewModel.tryToRefreshCookies()

--- a/Course/Course/Presentation/Container/CourseContainerView.swift
+++ b/Course/Course/Presentation/Container/CourseContainerView.swift
@@ -78,7 +78,7 @@ public struct CourseContainerView: View {
         ZStack(alignment: .top) {
             content
         }
-        .navigationBarHidden(true)
+        .hideNavigationBar(true)
         .navigationBarBackButtonHidden(true)
         .navigationTitle(title)
         .onChange(of: viewModel.selection, perform: didSelect)
@@ -324,9 +324,6 @@ public struct CourseContainerView: View {
         .versionedTabStyle()
         .introspect(.scrollView, on: .iOS(.v16...), customize: { tabView in
             tabView.isScrollEnabled = false
-        })
-        .introspect(.viewController, on: .iOS(.v15), customize: { controller in
-            controller.navigationController?.setNavigationBarHidden(true, animated: false)
         })
         .accentColor(Theme.Colors.accentXColor)
         .onFirstAppear {

--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -218,9 +218,13 @@ public class CourseContainerViewModel: BaseCourseViewModel {
     
     @MainActor
     func updateMenuBarVisibility() {
-        shouldHideMenuBar =
-            courseStructure == nil ||
-            courseStructure?.coursewareAccessDetails?.coursewareAccess?.hasAccess == false
+        if #available(iOS 16.0, *) {
+            shouldHideMenuBar =
+                courseStructure == nil ||
+                courseStructure?.coursewareAccessDetails?.coursewareAccess?.hasAccess == false
+        } else {
+            shouldHideMenuBar = true
+        }
     }
     
     @MainActor

--- a/Course/Course/Presentation/Dates/CourseDatesView.swift
+++ b/Course/Course/Presentation/Dates/CourseDatesView.swift
@@ -50,6 +50,7 @@ public struct CourseDatesView: View {
                             .padding(.top, 200)
                             .padding(.horizontal)
                     }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if let courseDates = viewModel.courseDates, !courseDates.courseDateBlocks.isEmpty {
                     CourseDateListView(
                         viewModel: viewModel,

--- a/Course/Course/Presentation/Handouts/HandoutsUpdatesDetailView.swift
+++ b/Course/Course/Presentation/Handouts/HandoutsUpdatesDetailView.swift
@@ -105,16 +105,13 @@ public struct HandoutsUpdatesDetailView: View {
                 }
             }
         }
-        .navigationBarHidden(false)
+        .hideNavigationBar(false)
         .navigationBarBackButtonHidden(false)
         .navigationTitle(title)
         .onChange(of: colorSchemeNative) { _ in
             guard UIApplication.shared.applicationState == .active else { return }
             updateColorScheme()
         }
-        .introspect(.viewController, on: .iOS(.v15), customize: { controller in
-            controller.navigationController?.setNavigationBarHidden(false, animated: false)
-        })
     }
     
     private var webViewHtml: some View {

--- a/Course/Course/Presentation/Handouts/HandoutsUpdatesDetailView.swift
+++ b/Course/Course/Presentation/Handouts/HandoutsUpdatesDetailView.swift
@@ -112,6 +112,9 @@ public struct HandoutsUpdatesDetailView: View {
             guard UIApplication.shared.applicationState == .active else { return }
             updateColorScheme()
         }
+        .introspect(.viewController, on: .iOS(.v15), customize: { controller in
+            controller.navigationController?.setNavigationBarHidden(false, animated: false)
+        })
     }
     
     private var webViewHtml: some View {

--- a/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalView.swift
+++ b/Course/Course/Presentation/Outline/CourseVertical/CourseVerticalView.swift
@@ -168,7 +168,7 @@ public struct CourseVerticalView: View {
                 }
             }
         }
-        .navigationBarHidden(false)
+        .hideNavigationBar(false)
         .navigationBarBackButtonHidden(false)
         .navigationTitle(title)
         .background(

--- a/Course/Course/Presentation/Unit/CourseUnitView.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitView.swift
@@ -135,7 +135,7 @@ public struct CourseUnitView: View {
                 showDiscussion = viewModel.selectedLesson().type == .discussion
             }
         }
-        .navigationBarHidden(true)
+        .hideNavigationBar(true)
         .navigationBarBackButtonHidden(true)
         .navigationTitle("")
         .background(

--- a/Course/Course/Presentation/Unit/Subviews/NotAvailableOnMobileView.swift
+++ b/Course/Course/Presentation/Unit/Subviews/NotAvailableOnMobileView.swift
@@ -40,6 +40,6 @@ public struct NotAvailableOnMobileView: View {
             }
             .padding(24)
         }
-        .navigationBarHidden(false)
+        .hideNavigationBar(false)
     }
 }

--- a/Dashboard/Dashboard/Presentation/AllCoursesView.swift
+++ b/Dashboard/Dashboard/Presentation/AllCoursesView.swift
@@ -164,7 +164,7 @@ public struct AllCoursesView: View {
                     .ignoresSafeArea()
             )
             .navigationBarBackButtonHidden(true)
-            .navigationBarHidden(true)
+            .hideNavigationBar(true)
             .navigationTitle(DashboardLocalization.Learn.allCourses)
         }
     }

--- a/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
@@ -223,7 +223,7 @@ public struct PrimaryCourseDashboardView<ProgramView: View>: View {
                     .ignoresSafeArea()
             )
             .navigationBarBackButtonHidden(true)
-            .navigationBarHidden(true)
+            .hideNavigationBar(true)
             .navigationTitle(DashboardLocalization.title)
         }
     }

--- a/Discovery/Discovery/Presentation/NativeDiscovery/CourseDetailsView.swift
+++ b/Discovery/Discovery/Presentation/NativeDiscovery/CourseDetailsView.swift
@@ -166,7 +166,7 @@ public struct CourseDetailsView: View {
                     }
                 }
             }.padding(.top, 8)
-            .navigationBarHidden(false)
+            .hideNavigationBar(false)
             .navigationBarBackButtonHidden(false)
             .navigationTitle(DiscoveryLocalization.Details.title)
             

--- a/Discovery/Discovery/Presentation/NativeDiscovery/DiscoveryView.swift
+++ b/Discovery/Discovery/Presentation/NativeDiscovery/DiscoveryView.swift
@@ -179,7 +179,7 @@ public struct DiscoveryView: View {
                     }
                 }
             }
-            .navigationBarHidden(sourceScreen != .startup)
+            .hideNavigationBar(sourceScreen != .startup)
             .onFirstAppear {
                 if !(searchQuery.isEmpty) {
                     router.showDiscoverySearch(searchQuery: searchQuery)

--- a/Discovery/Discovery/Presentation/NativeDiscovery/SearchView.swift
+++ b/Discovery/Discovery/Presentation/NativeDiscovery/SearchView.swift
@@ -161,7 +161,7 @@ public struct SearchView: View {
                 }
             }
             .navigationBarBackButtonHidden(true)
-            .navigationBarHidden(true)
+            .hideNavigationBar(true)
             .onAppear {
                 DispatchQueue.main.asyncAfter(deadline: .now()) {
                     withAnimation(.easeIn(duration: 0.3)) {

--- a/Discovery/Discovery/Presentation/WebDiscovery/DiscoveryWebview.swift
+++ b/Discovery/Discovery/Presentation/WebDiscovery/DiscoveryWebview.swift
@@ -162,7 +162,7 @@ public struct DiscoveryWebview: View {
                 }
             }
         }
-        .navigationBarHidden(viewModel.sourceScreen == .default && discoveryType == .discovery)
+        .hideNavigationBar(viewModel.sourceScreen == .default && discoveryType == .discovery)
         .navigationTitle(CoreLocalization.Mainscreen.discovery)
         .background(Theme.Colors.background.ignoresSafeArea())
         .onFirstAppear {

--- a/Discovery/Discovery/Presentation/WebPrograms/ProgramWebviewView.swift
+++ b/Discovery/Discovery/Presentation/WebPrograms/ProgramWebviewView.swift
@@ -121,7 +121,7 @@ public struct ProgramWebviewView: View {
                 }
             }
         }
-        .navigationBarHidden(viewType == .program)
+        .hideNavigationBar(viewType == .program)
         .navigationTitle(CoreLocalization.Mainscreen.programs)
         .background(Theme.Colors.background.ignoresSafeArea())
         .animation(.default, value: viewModel.showError)

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
@@ -208,7 +208,7 @@ public struct ResponsesView: View {
                 }
             }
             .ignoresSafeArea(.all, edges: .horizontal)
-            .navigationBarHidden(false)
+            .hideNavigationBar(false)
             .navigationBarBackButtonHidden(true)
             .navigationTitle(title)
             .toolbar {

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
@@ -225,7 +225,7 @@ public struct ThreadView: View {
                 }
             }
             .ignoresSafeArea(.all, edges: .horizontal)
-            .navigationBarHidden(false)
+            .hideNavigationBar(false)
             .navigationBarBackButtonHidden(true)
             .navigationTitle(title)
             .toolbar {

--- a/Discussion/Discussion/Presentation/CreateNewThread/CreateNewThreadView.swift
+++ b/Discussion/Discussion/Presentation/CreateNewThread/CreateNewThreadView.swift
@@ -190,7 +190,7 @@ public struct CreateNewThreadView: View {
                     }
                 }.padding(.top, 8)
             }
-            .navigationBarHidden(false)
+            .hideNavigationBar(false)
             .navigationBarBackButtonHidden(false)
             .navigationTitle(DiscussionLocalization.CreateThread.newPost)
             .background(

--- a/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionSearchTopicsView.swift
+++ b/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionSearchTopicsView.swift
@@ -149,7 +149,7 @@ public struct DiscussionSearchTopicsView: View {
             .background(Theme.Colors.background.ignoresSafeArea())
             .avoidKeyboard(dismissKeyboardByTap: true)
             .navigationBarBackButtonHidden(true)
-            .navigationBarHidden(true)
+            .hideNavigationBar(true)
             .navigationTitle(DiscussionLocalization.search)
             .onAppear {
                 DispatchQueue.main.asyncAfter(deadline: .now()) {
@@ -157,9 +157,6 @@ public struct DiscussionSearchTopicsView: View {
                         animated = true
                     }
                 }
-            }
-            .introspect(.viewController, on: .iOS(.v15)) { controller in
-                controller.navigationController?.setNavigationBarHidden(true, animated: false)
             }
         }
     }

--- a/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionTopicsView.swift
+++ b/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionTopicsView.swift
@@ -205,7 +205,7 @@ public struct DiscussionTopicsView: View {
                     await viewModel.getTopics(courseID: courseID)
                 }
             }
-            .navigationBarHidden(false)
+            .hideNavigationBar(false)
             .navigationBarBackButtonHidden(false)
             .navigationTitle(viewModel.title)
             .background(

--- a/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionTopicsView.swift
+++ b/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionTopicsView.swift
@@ -205,7 +205,6 @@ public struct DiscussionTopicsView: View {
                     await viewModel.getTopics(courseID: courseID)
                 }
             }
-            .hideNavigationBar(false)
             .navigationBarBackButtonHidden(false)
             .navigationTitle(viewModel.title)
             .background(

--- a/Discussion/Discussion/Presentation/Posts/PostsView.swift
+++ b/Discussion/Discussion/Presentation/Posts/PostsView.swift
@@ -236,7 +236,7 @@ public struct PostsView: View {
                     )
                 }
             }
-            .navigationBarHidden(!showTopMenu)
+            .hideNavigationBar(!showTopMenu)
             .navigationBarBackButtonHidden(!showTopMenu)
             .navigationTitle(title)
             .background(

--- a/OpenEdX/View/MainScreenView.swift
+++ b/OpenEdX/View/MainScreenView.swift
@@ -19,7 +19,6 @@ struct MainScreenView: View {
     
     @State private var disableAllTabs: Bool = false
     @State private var updateAvailable: Bool = false
-    @State private var isVisible: Bool = false
     
     @ObservedObject private(set) var viewModel: MainScreenViewModel
     
@@ -186,12 +185,6 @@ struct MainScreenView: View {
                 viewModel.trackMainProfileTabClicked()
             }
         })
-        .onAppear {
-            isVisible = true
-        }
-        .onDisappear {
-            isVisible = false
-        }
         .onFirstAppear {
             Task {
                 await viewModel.prefetchDataForOffline()
@@ -202,7 +195,7 @@ struct MainScreenView: View {
         }
         .accentColor(Theme.Colors.accentXColor)
         .introspect(.viewController, on: .iOS(.v15)) { controller in
-            if isVisible && viewModel.selection != .profile {
+            if viewModel.selection == .dashboard {
                 controller.navigationController?.setNavigationBarHidden(true, animated: false)
             }
         }

--- a/OpenEdX/View/MainScreenView.swift
+++ b/OpenEdX/View/MainScreenView.swift
@@ -144,7 +144,7 @@ struct MainScreenView: View {
             .tag(MainTab.profile)
             .accessibilityIdentifier("profile_tabitem")
         }
-        .navigationBarHidden(viewModel.selection == .dashboard)
+        .hideNavigationBar(viewModel.selection == .dashboard)
         .navigationBarBackButtonHidden(viewModel.selection == .dashboard)
         .navigationTitle(titleBar())
         .toolbar {
@@ -194,11 +194,6 @@ struct MainScreenView: View {
             }
         }
         .accentColor(Theme.Colors.accentXColor)
-        .introspect(.viewController, on: .iOS(.v15)) { controller in
-            if viewModel.selection == .dashboard {
-                controller.navigationController?.setNavigationBarHidden(true, animated: false)
-            }
-        }
     }
     
     @ViewBuilder

--- a/OpenEdX/View/MainScreenView.swift
+++ b/OpenEdX/View/MainScreenView.swift
@@ -19,6 +19,7 @@ struct MainScreenView: View {
     
     @State private var disableAllTabs: Bool = false
     @State private var updateAvailable: Bool = false
+    @State private var isVisible: Bool = false
     
     @ObservedObject private(set) var viewModel: MainScreenViewModel
     
@@ -185,6 +186,12 @@ struct MainScreenView: View {
                 viewModel.trackMainProfileTabClicked()
             }
         })
+        .onAppear {
+            isVisible = true
+        }
+        .onDisappear {
+            isVisible = false
+        }
         .onFirstAppear {
             Task {
                 await viewModel.prefetchDataForOffline()
@@ -195,7 +202,9 @@ struct MainScreenView: View {
         }
         .accentColor(Theme.Colors.accentXColor)
         .introspect(.viewController, on: .iOS(.v15)) { controller in
-            controller.navigationController?.setNavigationBarHidden(true, animated: false)
+            if isVisible && viewModel.selection != .profile {
+                controller.navigationController?.setNavigationBarHidden(true, animated: false)
+            }
         }
     }
     

--- a/Profile/Profile/Presentation/DatesAndCalendar/CoursesToSyncView.swift
+++ b/Profile/Profile/Presentation/DatesAndCalendar/CoursesToSyncView.swift
@@ -71,7 +71,7 @@ public struct CoursesToSyncView: View {
                     .roundedBackground(Theme.Colors.background)
                     .ignoresSafeArea(.all, edges: .bottom)
                 }
-                .navigationBarHidden(true)
+                .hideNavigationBar(true)
                 .navigationBarBackButtonHidden(true)
                 
                 if viewModel.showError {

--- a/Profile/Profile/Presentation/DatesAndCalendar/DatesAndCalendarView.swift
+++ b/Profile/Profile/Presentation/DatesAndCalendar/DatesAndCalendarView.swift
@@ -52,7 +52,7 @@ public struct DatesAndCalendarView: View {
                     .roundedBackground(Theme.Colors.background)
                     .ignoresSafeArea(.all, edges: .bottom)
                 }
-                .navigationBarHidden(true)
+                .hideNavigationBar(true)
                 .navigationBarBackButtonHidden(true)
                 
                 // Error Alert if needed

--- a/Profile/Profile/Presentation/DatesAndCalendar/SyncCalendarOptionsView.swift
+++ b/Profile/Profile/Presentation/DatesAndCalendar/SyncCalendarOptionsView.swift
@@ -103,7 +103,7 @@ public struct SyncCalendarOptionsView: View {
                     .roundedBackground(Theme.Colors.background)
                     .ignoresSafeArea(.all, edges: .bottom)
                 }
-                .navigationBarHidden(true)
+                .hideNavigationBar(true)
                 .navigationBarBackButtonHidden(true)
                 
                 // Error Alert if needed

--- a/Profile/Profile/Presentation/DeleteAccount/DeleteAccountView.swift
+++ b/Profile/Profile/Presentation/DeleteAccount/DeleteAccountView.swift
@@ -142,7 +142,7 @@ public struct DeleteAccountView: View {
                        maxHeight: .infinity,
                        alignment: .top)
                 .padding(.top, 8)
-                .navigationBarHidden(false)
+                .hideNavigationBar(false)
                 .navigationBarBackButtonHidden(true)
                 .navigationTitle(ProfileLocalization.DeleteAccount.title)
                 .toolbar {

--- a/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
+++ b/Profile/Profile/Presentation/EditProfile/EditProfileView.swift
@@ -235,7 +235,7 @@ public struct EditProfileView: View {
                         .accessibilityIdentifier("progress_bar")
                 }
             }
-            .navigationBarHidden(false)
+            .hideNavigationBar(false)
             .navigationBarBackButtonHidden(true)
             .navigationTitle(ProfileLocalization.editProfile)
             .toolbar {

--- a/Profile/Profile/Presentation/Profile/ProfileView.swift
+++ b/Profile/Profile/Presentation/Profile/ProfileView.swift
@@ -33,7 +33,7 @@ public struct ProfileView: View {
                 )
                 .accessibilityAction {}
                 .padding(.top, 8)
-                .navigationBarHidden(false)
+                .hideNavigationBar(false)
                 .navigationBarBackButtonHidden(false)
                 .navigationTitle(ProfileLocalization.title)
                 

--- a/Profile/Profile/Presentation/Profile/UserProfile/UserProfileView.swift
+++ b/Profile/Profile/Presentation/Profile/UserProfile/UserProfileView.swift
@@ -85,7 +85,7 @@ public struct UserProfileView: View {
                     .frameLimit(width: proxy.size.width)
                 }
                 .padding(.top, 8)
-                .navigationBarHidden(false)
+                .hideNavigationBar(false)
                 .navigationBarBackButtonHidden(false)
                 
                 // MARK: - Error Alert

--- a/Profile/Profile/Presentation/Settings/ManageAccountView.swift
+++ b/Profile/Profile/Presentation/Settings/ManageAccountView.swift
@@ -79,7 +79,7 @@ public struct ManageAccountView: View {
                     .padding(.horizontal, isHorizontal ? 24 : 0)
                     .roundedBackground(Theme.Colors.background)
                 }
-                .navigationBarHidden(true)
+                .hideNavigationBar(true)
                 .navigationBarBackButtonHidden(true)
                 .navigationTitle(ProfileLocalization.manageAccount)
                 

--- a/Profile/Profile/Presentation/Settings/SettingsView.swift
+++ b/Profile/Profile/Presentation/Settings/SettingsView.swift
@@ -88,7 +88,7 @@ public struct SettingsView: View {
                     }
                     .roundedBackground(Theme.Colors.background)
                 }
-                .navigationBarHidden(true)
+                .hideNavigationBar(true)
                 .navigationBarBackButtonHidden(true)
                 .navigationTitle(ProfileLocalization.settings)
                 

--- a/Profile/Profile/Presentation/Settings/VideoQualityView.swift
+++ b/Profile/Profile/Presentation/Settings/VideoQualityView.swift
@@ -111,7 +111,7 @@ public struct VideoQualityView: View {
                 }
             }
         }
-        .navigationBarHidden(true)
+        .hideNavigationBar(true)
         .navigationBarBackButtonHidden(true)
         .navigationTitle(ProfileLocalization.Settings.videoQualityTitle)
         .ignoresSafeArea(.all, edges: .horizontal)

--- a/Profile/Profile/Presentation/Settings/VideoSettingsView.swift
+++ b/Profile/Profile/Presentation/Settings/VideoSettingsView.swift
@@ -115,7 +115,7 @@ public struct VideoSettingsView: View {
                 }
             }
         }
-        .navigationBarHidden(true)
+        .hideNavigationBar(true)
         .navigationBarBackButtonHidden(true)
         .navigationTitle(ProfileLocalization.Settings.videoSettingsTitle)
         .ignoresSafeArea(.all, edges: .horizontal)


### PR DESCRIPTION
PR contains fix for iOS 15. It removes top tab bar

Before | After
--|--
![Simulator Screenshot - iPhone 7 - 2024-07-30 at 16 38 30](https://github.com/user-attachments/assets/17120fb3-6fc0-4f75-b89d-c1db08d454b4) | ![Simulator Screenshot - iPhone 7 - 2024-07-30 at 16 36 02](https://github.com/user-attachments/assets/ffdcdf9b-f102-486c-9ada-65b84ca7d852)


Also contains fix for navigation bar in announcement page.

Added PRIVATE value for account privacy

Added color fix for ios 15 bottom tab bar

Added navigation bar fix for iOS 15 when it disappears in some places (ProgramWebview, DiscoveryWebview, Handouts details)