### PR TITLE
fix: Remove urls from headings of End User lisence agreements

### DIFF
--- a/Authorization/Authorization/Presentation/Base/FieldsView.swift
+++ b/Authorization/Authorization/Presentation/Base/FieldsView.swift
@@ -115,7 +115,7 @@ struct FieldsView: View {
     }
 
     private func handleURL(_ url: URL) -> OpenURLAction.Result {
-        router.showWebBrowser(title: url.host ?? "", url: url)
+        router.showWebBrowser(title: "", url: url)
         return .handled
     }
 }

--- a/Authorization/Authorization/Presentation/Login/SignInView.swift
+++ b/Authorization/Authorization/Presentation/Login/SignInView.swift
@@ -211,7 +211,7 @@ public struct SignInView: View {
         .hideNavigationBar()
         .ignoresSafeArea(.all, edges: .horizontal)
         .background(Theme.Colors.background.ignoresSafeArea(.all))
-        .onFirstAppear{
+        .onFirstAppear {
             viewModel.trackScreenEvent()
         }
     }
@@ -240,7 +240,7 @@ public struct SignInView: View {
     }
 
     private func handleURL(_ url: URL) -> OpenURLAction.Result {
-        viewModel.router.showWebBrowser(title: url.host ?? "", url: url)
+        viewModel.router.showWebBrowser(title: "", url: url)
         return .handled
     }
 }


### PR DESCRIPTION
Fix bug bash reported issue:
```Login/Register screen > End User lisence agreements links are showing URL in the heading ```