### PR TITLE
fix: Vertical scroll bar overlapping with UI components

### DIFF
--- a/Profile/Profile/Presentation/DeleteAccount/DeleteAccountView.swift
+++ b/Profile/Profile/Presentation/DeleteAccount/DeleteAccountView.swift
@@ -136,8 +136,8 @@ public struct DeleteAccountView: View {
                         .accessibilityIdentifier("back_button")
                     }
                     .frameLimit(width: proxy.size.width)
+                    .padding(.horizontal, 24)
                 }
-                .padding(.horizontal, 24)
                 .frame(minHeight: 0,
                        maxHeight: .infinity,
                        alignment: .top)


### PR DESCRIPTION
Fix bug bash reported issue:
```Delete Account screen > Slider is overlapping with 'delete account' and 'Back to profile' button```


Before Fix | After Fix
--- | ---
<video src="https://github.com/user-attachments/assets/e5e3c339-2228-438d-a59e-38fe6d163eb3" /> | <video src="https://github.com/user-attachments/assets/118a4659-4672-4275-88f9-68edf82c9e27" />