### PR TITLE
fix: video crashes

### DIFF
--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -272,7 +272,7 @@ public class CourseRepository: CourseRepositoryProtocol {
     }
     
     private func parseVideo(encodedVideo: DataLayer.EncodedVideoData?) -> CourseBlockVideo? {
-        guard let encodedVideo else {
+        guard let encodedVideo, encodedVideo.url?.isEmpty == false else {
             return nil
         }
         return .init(

--- a/Course/Course/Domain/CourseInteractor.swift
+++ b/Course/Course/Domain/CourseInteractor.swift
@@ -198,9 +198,15 @@ public class CourseInteractor: CourseInteractorProtocol {
                 let endTime = startAndEndTimes.last ?? "00:00:00,000"
                 let text = lines[2..<lines.count].joined(separator: "\n")
                 
+                let startTimeInterval = Date(subtitleTime: startTime)
+                var endTimeInverval = Date(subtitleTime: endTime)
+                if startTimeInterval > endTimeInverval {
+                    endTimeInverval = startTimeInterval
+                }
+                
                 let subtitle = Subtitle(id: id,
-                                        fromTo: DateInterval(start: Date(subtitleTime: startTime),
-                                                             end: Date(subtitleTime: endTime)),
+                                        fromTo: DateInterval(start: startTimeInterval,
+                                                             end: endTimeInverval),
                                         text: text.decodedHTMLEntities())
                 subtitles.append(subtitle)
             }

--- a/Course/Course/Presentation/Video/PlayerTrackerProtocol.swift
+++ b/Course/Course/Presentation/Video/PlayerTrackerProtocol.swift
@@ -111,7 +111,13 @@ public class PlayerTracker: PlayerTrackerProtocol {
             item = AVPlayerItem(url: url)
         }
         self.player = AVPlayer(playerItem: item)
-        timePublisher = CurrentValueSubject(player?.currentTime().seconds ?? 0)
+        
+        var playerTime = player?.currentTime().seconds ?? 0.0
+        if playerTime.isNaN == true {
+            playerTime = 0.0
+        }
+        
+        timePublisher = CurrentValueSubject(playerTime)
         ratePublisher = CurrentValueSubject(player?.rate ?? 0)
         finishPublisher = PassthroughSubject<Void, Never>()
         readyPublisher = PassthroughSubject<Bool, Never>()

--- a/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
+++ b/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
@@ -72,7 +72,11 @@ public class VideoPlayerViewModel: ObservableObject {
         
         playerHolder.getTimePublisher()
             .sink {[weak self] time in
-                self?.currentTime = time
+                if time.isNaN {
+                    self?.currentTime = 0.0
+                } else {
+                    self?.currentTime = time
+                }
             }
             .store(in: &subscription)
         playerHolder.getErrorPublisher()
@@ -103,7 +107,7 @@ public class VideoPlayerViewModel: ObservableObject {
 
             subtitles = result
         } catch {
-            print(">>>>> ⛔️⛔️⛔️⛔️⛔️⛔️⛔️⛔️", error)
+            debugLog(">>>>> ⛔️⛔️⛔️⛔️⛔️⛔️⛔️⛔️", error)
         }
     }
     

--- a/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
+++ b/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
@@ -72,11 +72,7 @@ public class VideoPlayerViewModel: ObservableObject {
         
         playerHolder.getTimePublisher()
             .sink {[weak self] time in
-                if time.isNaN {
-                    self?.currentTime = 0.0
-                } else {
-                    self?.currentTime = time
-                }
+                self?.currentTime = time
             }
             .store(in: &subscription)
         playerHolder.getErrorPublisher()


### PR DESCRIPTION
App was crashing in two cases of videos, both the crashes can be tested on course `Project Management for Development`

1. When the LMS is returning an empty URL for video encoding

How it can be tested: 
    It can be tested on the first section, `Start here` -> `0.1 Welcome to the course` -> going to the video
Solution: 
    Mimic the behaviour from the old app.
2. When the LMS returns wrong data for transcripts, LSM is returning less time for endtime than the starttime of the transcript.

How it can be tested: 
    1. Go to Videos tab
    2. Go to Module 1: Project Chapter 
    3. Go to 1.1.5 Video: Project Chapter (can be selected from the dropdown switcher)
    4. Go to the video component 
    
