### PR TITLE
chore: limit the number of CTAs on the Primary Card on the Learn Tab

### DIFF
--- a/Dashboard/Dashboard/Presentation/Elements/PrimaryCardView.swift
+++ b/Dashboard/Dashboard/Presentation/Elements/PrimaryCardView.swift
@@ -32,6 +32,9 @@ public struct PrimaryCardView: View {
     private var upgradeAction: () -> Void
     private var isUpgradeable: Bool
     @Environment(\.isHorizontal) var isHorizontal
+    private var canShowFutureAssignments: Bool {
+        return !isUpgradeable || pastAssignments.count <= 0
+    }
     
     public init(
         courseName: String,
@@ -160,7 +163,7 @@ public struct PrimaryCardView: View {
             }
             
             // futureAssignment
-            if !futureAssignments.isEmpty {
+            if !futureAssignments.isEmpty && canShowFutureAssignments {
                 if futureAssignments.count == 1, let futureAssignment = futureAssignments.first {
                     let daysRemaining = Calendar.current.dateComponents(
                         [.day],
@@ -179,7 +182,7 @@ public struct PrimaryCardView: View {
                             assignmentAction(futureAssignments.first?.firstComponentBlockId)
                         }
                     )
-                } else if futureAssignments.count > 1 {
+                } else if futureAssignments.count > 1 && canShowFutureAssignments {
                     if let firtsData = futureAssignments.sorted(by: { $0.date < $1.date }).first {
                         courseButton(
                             title: DashboardLocalization.Learn.PrimaryCard.futureAssignments(


### PR DESCRIPTION
We need to limit the number of CTAs present on the Primary Course Card on the Learn tab to 3 as follows:

- Start/Resume Course CTA
- Upgrade Course CTA
- Past Due/Upcoming Assignment Date

If the upgrade button is displayed on the Primary Course Card then we can either show the CTA for items that are Past Due or Upcoming items in the course.

If the condition exists for both buttons to exist at the same time then  the Past Due items CTA should be given priority over Upcoming items CTA. 