### PR TITLE
fix: fix iPad crash of alert controller

### DIFF
--- a/Core/Core/View/Base/Webview/WebView.swift
+++ b/Core/Core/View/Base/Webview/WebView.swift
@@ -122,6 +122,17 @@ public struct WebView: UIViewRepresentable {
                 handler: { _ in
                     completionHandler(false)
                 }))
+            
+            if let presenter = alertController.popoverPresentationController {
+                let view = UIApplication.topViewController()?.view
+                presenter.sourceView = view
+                presenter.sourceRect = CGRect(
+                    x: view?.bounds.midX ?? 0,
+                    y: view?.bounds.midY ?? 0,
+                    width: 0,
+                    height: 0
+                )
+            }
 
             UIApplication.topViewController()?.present(alertController, animated: true, completion: nil)
         }


### PR DESCRIPTION
This PR fixes the following iPad Crash. Although I couldn't reproduce the crash in the actual case, the crash happened when I ran the same code by clicking a button.

<img width="1117" alt="crash_logs" src="https://github.com/user-attachments/assets/09e5a7e5-3e4b-4f77-8de5-2954b59f1a7c">
