### PR TITLE
fix: fix gallery privacy policy violation crash

### DIFF
--- a/OpenEdX/Info.plist
+++ b/OpenEdX/Info.plist
@@ -39,5 +39,7 @@
 	<string>We would like to utilize your calendar list to subscribe you to your personalized calendar for this course.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>We would like to utilize your calendar list to subscribe you to your personalized calendar for this course.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Allow access to your photo library so you can save photos in your gallery.</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR fixes the following crash: 

https://console.firebase.google.com/u/1/project/openedx-mobile/crashlytics/app/ios:org.edx.mobile/issues/5ac8785ef88998bfaf4f9a6af4a39ac3?versions=6.0.2%20(5)&time=last-seven-days&types=crash&sessionEventKey=036b6a3c92b74d1380efc0f62536c1f1_1988996911041445115

Steps to reproduce the crash:
1. Sign-in 
2. Go to any block that has an image in it
3. Long press on the image
4. Select the `Save to Photos` option from the pop-up menu

