### PR TITLE
feat: Fullstory SwiftUI Automatic Selector Preview

### DIFF
--- a/OpenEdX.xcodeproj/project.pbxproj
+++ b/OpenEdX.xcodeproj/project.pbxproj
@@ -73,6 +73,34 @@
 		E0D6E6A42B1626D60089F9C9 /* Theme.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E0D6E6A22B1626B10089F9C9 /* Theme.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
+/* Begin PBXBuildRule section */
+		97C7D9712C7E115E00C1BDC0 /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			fileType = sourcecode.swift;
+			inputFiles = (
+			);
+			isEditable = 1;
+			outputFiles = (
+				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE)_transformed.swift",
+			);
+			runOncePerArchitecture = 0;
+			script = "\"${BUILD_DIR%Build/*}/SourcePackages/artifacts/fullstory-swift-package-ios/fullstory/tools/FullStorySwiftUITransformer\" \"$SCRIPT_INPUT_FILE\" \"$DERIVED_FILE_DIR/${INPUT_FILE_BASE}_transformed.swift\"\n";
+		};
+		97C7D9722C7E571800C1BDC0 /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.xcode.tools.swift.compiler;
+			filePatterns = "*_transformed.swift";
+			fileType = pattern.proxy;
+			inputFiles = (
+			);
+			isEditable = 1;
+			outputFiles = (
+			);
+			script = "# Type a script or drag a script file from your workspace to insert its path.\n";
+		};
+/* End PBXBuildRule section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		0770DE1528D07845006D8A5D /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -431,6 +459,8 @@
 				02F175442A4E3B320019CD70 /* FirebaseCrashlytics */,
 			);
 			buildRules = (
+				97C7D9722C7E571800C1BDC0 /* PBXBuildRule */,
+				97C7D9712C7E115E00C1BDC0 /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
@@ -565,7 +595,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [\"$ FULLSTORY_ENABLED\" = \"YES\"]; then\n    \"${PODS_ROOT}/FullStory/tools/FullStoryCommandLine\" \"${CONFIGURATION_BUILD_DIR}/${WRAPPER_NAME}\"\nfi\n";
+			shellScript = "\"${BUILD_DIR%Build/*}/SourcePackages/artifacts/fullstory-swift-package-ios/fullstory/tools/FullStoryCommandLine\" \"${CONFIGURATION_BUILD_DIR}/${WRAPPER_NAME}\"\n";
 		};
 		B9442FD26CE9A85A43FC2CFA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -868,6 +898,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = STAGE;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1052,6 +1083,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEV;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1236,6 +1268,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = PROD;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1287,7 +1320,7 @@
 			repositoryURL = "https://github.com/fullstorydev/fullstory-swift-package-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.49.0;
+				minimumVersion = 1.51.1;
 			};
 		};
 		A51CDBEB2B6D2BEE009B6D4E /* XCRemoteSwiftPackageReference "braze-segment-swift" */ = {

--- a/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
+++ b/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
@@ -55,6 +55,17 @@ class AnalyticsManager: AuthorizationAnalytics,
             analyticsServices.append(segmentService)
         }
         
+        /**
+         This check is `edX/2U` specific.
+         We only want to record FullStory events for the `PROD` environment for the following reasons:
+         1. `Dev` & `Stage` environments has `orgID` of Test Organization named `2U - Mobile Apps`, and we do not want to record
+         events or other data for this test organization.
+         2. Initially, we set up conditional loading for the FullStory SDK, but it caused issues with enabling SwiftUI-based views in FullStory sessions.
+         We reached out to FullStory's technical support team, who informed us that conditional integration of the FullStory SDK is not possible. As a
+         workaround, we used the test organization `2U - Mobile Apps` and its `orgID` for the `Dev` and `Stage` environments to avoid
+         disrupting the SDK functionality. We have also communicated our usage strategy to FullStory's support team and requested a more effective
+         solution in future SDK updates.
+         */
         #if PROD
         if config.fullStory.enabled,
            let fullStoryService = Container.shared.resolve(

--- a/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
+++ b/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
@@ -55,6 +55,7 @@ class AnalyticsManager: AuthorizationAnalytics,
             analyticsServices.append(segmentService)
         }
         
+        #if PROD
         if config.fullStory.enabled,
            let fullStoryService = Container.shared.resolve(
             FullStoryAnalyticsService.self,
@@ -62,6 +63,7 @@ class AnalyticsManager: AuthorizationAnalytics,
            ) {
             analyticsServices.append(fullStoryService)
         }
+        #endif
         
         return analyticsServices
     }

--- a/OpenEdX/Managers/FullStoryAnalyticsService/FullStoryAnalyticsService.swift
+++ b/OpenEdX/Managers/FullStoryAnalyticsService/FullStoryAnalyticsService.swift
@@ -17,6 +17,7 @@ class FullStoryAnalyticsService: NSObject, AnalyticsService, FSDelegate {
         self.firebaseEnabled = firebaseEnabled
         super.init()
         FS.delegate = self
+        FS.restart()
     }
     
     func identify(id: String, username: String?, email: String?) {

--- a/config_script/process_config.py
+++ b/config_script/process_config.py
@@ -252,9 +252,27 @@ class ConfigurationManager:
         fullstory = config.get('FULLSTORY', {})
         enabled = fullstory.get('ENABLED')
         orgID = fullstory.get('ORG_ID')
+        recordOnStart = fullstory.get('RECORD_ON_START')
+        swiftUIEnabled = fullstory.get('SWIFTUI_ENABLED')
+        swiftUISelectorVersion = fullstory.get('SWIFTUI_SELECTOR_VERSION')
+        swiftUIPreviewVersion = fullstory.get('SWIFTUI_PREVIEW_VERSION')
 
         if enabled and orgID:
-            plist["FullStory"] = {"orgID": orgID}
+            plist["FullStory"] = {
+            "orgID": orgID,
+            "RecordOnStart": recordOnStart,
+            "SwiftUIEnabled": swiftUIEnabled,
+            "SwiftUISelectorVersion": swiftUISelectorVersion,
+            "SwiftUISelectorPreview": swiftUIPreviewVersion
+            }
+        else:
+            plist["FullStory"] = {
+            "orgID": 'o-1XJF5N-na1',
+            "RecordOnStart": False,
+            "SwiftUIEnabled": True,
+            "SwiftUISelectorVersion": 3,
+            "SwiftUISelectorPreview": 2
+            }
 
     def update_info_plist(self, plist_data, plist_path):
         if not plist_path:

--- a/config_script/process_config.py
+++ b/config_script/process_config.py
@@ -267,7 +267,7 @@ class ConfigurationManager:
             }
         else:
             plist["FullStory"] = {
-            "orgID": 'o-1XJF5N-na1',
+            "orgID": '00000',
             "RecordOnStart": False,
             "SwiftUIEnabled": True,
             "SwiftUISelectorVersion": 3,


### PR DESCRIPTION
[LEARNER-10187](https://2u-internal.atlassian.net/browse/LEARNER-10187): iOS - FullStory: Add attributes to enable SwiftUI based views in FS sessions

**Config PRs:**
- [Frist](https://github.com/edx/edx-mobile-config/pull/176)
- [Second](https://github.com/edx/edx-mobile-config/pull/177)

**FullStory SwiftUI Page Insights & Inspect Mode elements**

- Events will be recorded for Prod environment if `ENABLED: true` in `shared.yaml` file
- Events will not be recorded for Prod environment if `ENABLED: false` in `shared.yaml` file
- We are setting test organization `orgID` as a fallback.
- Updated Build Phases path from **Pod** to **Packages**.
- Removed condition from build phase as suggested by FullStory technical support team.
`if ["$ FULLSTORY_ENABLED" = "YES"]`
- `fullstory_session_url` is recording just for Prod environment with `ENABLED: true` in `shared.yaml` file otherwise it will not record.

| Build Phases & Build Rules |
|----------|
| <img width="1280" alt="Screenshot 2024-09-10 at 7 31 03 PM" src="https://github.com/user-attachments/assets/e23c397f-2262-4271-9d40-81dd9a3d37c2"> |
| <img width="1283" alt="Screenshot 2024-09-10 at 7 30 30 PM" src="https://github.com/user-attachments/assets/875c251d-dc52-47f0-8913-30c9df7a8a35"> |

| FS Session Url |
|----------|
| <img width="1273" alt="Screenshot 2024-09-10 at 6 33 29 PM" src="https://github.com/user-attachments/assets/a605b14a-eab9-4eff-8062-6ff58d45ae27"> |
| <img width="1277" alt="Screenshot 2024-09-10 at 6 33 36 PM" src="https://github.com/user-attachments/assets/c8865186-7fb9-4f4a-8a29-ee6e05e4d279"> |

- For Dev, Stage environment, we will not record events and crashes on full story

| Active Compilation Conditions |
|----------|
| <img width="851" alt="Screenshot 2024-09-10 at 7 29 54 PM" src="https://github.com/user-attachments/assets/07c14d06-c6df-4ecb-95b4-1d1aff91ab6c"> |

**Note:** We are in discussion with FullStory technical support team for the case if we just have orgID for prod application and not want to use any orgID for Dev and Stage environments then what can be the solution for it?