### PR TITLE
chore: remove Russia from countries in edit profile section

### DIFF
--- a/OpenEdX/Base.lproj/сountries.json
+++ b/OpenEdX/Base.lproj/сountries.json
@@ -920,11 +920,6 @@
     "default": false
   },
   {
-    "value": "RU",
-    "name": "Russia",
-    "default": false
-  },
-  {
     "value": "RW",
     "name": "Rwanda",
     "default": false

--- a/OpenEdX/uk.lproj/сountries.json
+++ b/OpenEdX/uk.lproj/сountries.json
@@ -920,11 +920,6 @@
     "default": false
   },
   {
-    "value": "RU",
-    "name": "Росія",
-    "default": false
-  },
-  {
     "value": "RW",
     "name": "Руанда",
     "default": false


### PR DESCRIPTION
This PR removes Russia from countries in the edit profile section.

**How to test the PR:**
As for most users, the country picker in edit profile will be disabled because of `requires_parental_consent` so you can test the PR by passing enabled: true to the [countries picker](https://github.com/edx/edx-mobile-marketplace-ios/blob/2U/develop/Profile/Profile/Presentation/EditProfile/EditProfileView.swift#L106). 

| This is how the screen will look for users who selected Russia as a country without parental consent. | This is how the screen will look for users who selected Russia as their country and parental consent is required. |
|----------|----------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-09-12 at 10 27 56](https://github.com/user-attachments/assets/d12475d5-3986-4b45-821f-ff052e74d86d) | ![Simulator Screenshot - iPhone 15 Pro - 2024-09-12 at 10 33 53](https://github.com/user-attachments/assets/7ac06ef7-7819-4fad-afda-6b257fffc33a) |
