### PR TITLE
fix: Respect `student_view_multi_device` key for HTML xBlocks in the Block API

### DIFF
--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -245,15 +245,7 @@ public class CourseRepository: CourseRepositoryProtocol {
                 .replacingOccurrences(of: "?lang=\($0.key)", with: "")
             return SubtitleUrl(language: $0.key, url: url)
         }
-        
-        let type: BlockType = {
-            let initialType = BlockType(rawValue: block.type) ?? .unknown
-            if initialType == .html, let multiDevice = block.multiDevice {
-                return multiDevice ? initialType : .unknown
-            }
-            return initialType
-        }()
-        
+            
         return CourseBlock(
             blockId: block.blockId,
             id: block.id,
@@ -262,7 +254,7 @@ public class CourseRepository: CourseRepositoryProtocol {
             graded: block.graded,
             due: block.due == nil ? nil : Date(iso8601: block.due!),
             completion: block.completion ?? 0,
-            type: type,
+            type: BlockType(rawValue: block.type) ?? .unknown,
             displayName: block.displayName,
             studentUrl: block.studentUrl,
             webUrl: block.webUrl,
@@ -505,15 +497,7 @@ And there are various ways of describing it-- call it oral poetry or
             let url = $0.value
             return SubtitleUrl(language: $0.key, url: url)
         }
-        
-        let type: BlockType = {
-            let initialType = BlockType(rawValue: block.type) ?? .unknown
-            if initialType == .html, let multiDevice = block.multiDevice {
-                return multiDevice ? initialType : .unknown
-            }
-            return initialType
-        }()
-        
+            
         return CourseBlock(
             blockId: block.blockId,
             id: block.id,
@@ -522,7 +506,7 @@ And there are various ways of describing it-- call it oral poetry or
             graded: block.graded,
             due: block.due == nil ? nil : Date(iso8601: block.due!),
             completion: block.completion ?? 0,
-            type: type,
+            type: BlockType(rawValue: block.type) ?? .unknown,
             displayName: block.displayName,
             studentUrl: block.studentUrl,
             webUrl: block.webUrl,

--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -245,7 +245,15 @@ public class CourseRepository: CourseRepositoryProtocol {
                 .replacingOccurrences(of: "?lang=\($0.key)", with: "")
             return SubtitleUrl(language: $0.key, url: url)
         }
-            
+        
+        let type: BlockType = {
+            let initialType = BlockType(rawValue: block.type) ?? .unknown
+            if initialType == .html, let multiDevice = block.multiDevice {
+                return multiDevice ? initialType : .unknown
+            }
+            return initialType
+        }()
+        
         return CourseBlock(
             blockId: block.blockId,
             id: block.id,
@@ -254,7 +262,7 @@ public class CourseRepository: CourseRepositoryProtocol {
             graded: block.graded,
             due: block.due == nil ? nil : Date(iso8601: block.due!),
             completion: block.completion ?? 0,
-            type: BlockType(rawValue: block.type) ?? .unknown,
+            type: type,
             displayName: block.displayName,
             studentUrl: block.studentUrl,
             webUrl: block.webUrl,
@@ -497,7 +505,15 @@ And there are various ways of describing it-- call it oral poetry or
             let url = $0.value
             return SubtitleUrl(language: $0.key, url: url)
         }
-            
+        
+        let type: BlockType = {
+            let initialType = BlockType(rawValue: block.type) ?? .unknown
+            if initialType == .html, let multiDevice = block.multiDevice {
+                return multiDevice ? initialType : .unknown
+            }
+            return initialType
+        }()
+        
         return CourseBlock(
             blockId: block.blockId,
             id: block.id,
@@ -506,7 +522,7 @@ And there are various ways of describing it-- call it oral poetry or
             graded: block.graded,
             due: block.due == nil ? nil : Date(iso8601: block.due!),
             completion: block.completion ?? 0,
-            type: BlockType(rawValue: block.type) ?? .unknown,
+            type: type,
             displayName: block.displayName,
             studentUrl: block.studentUrl,
             webUrl: block.webUrl,

--- a/Course/Course/Presentation/Unit/CourseUnitViewModel.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitViewModel.swift
@@ -20,14 +20,12 @@ public enum LessonType: Equatable {
         switch block.type {
         case .course, .chapter, .vertical, .sequential:
             return .unknown(block.studentUrl)
-        case .unknown:
+        case .html, .unknown:
             if let multiDevice = block.multiDevice, multiDevice {
                 return .web(url: block.studentUrl, injections: mandatoryInjections)
             } else {
                 return .unknown(block.studentUrl)
             }
-        case .html:
-            return .web(url: block.studentUrl, injections: mandatoryInjections)
         case .discussion:
             return .discussion(block.topicId ?? "", block.id, block.displayName)
         case .video:


### PR DESCRIPTION
[LEARNER-10217](https://2u-internal.atlassian.net/browse/LEARNER-10217): Respect `student_view_multi_device` key for HTML xBlocks in the Block API

For HTML xBlocks, if the `student_view_multi_device` key is set to `false`, the HTML xBlock will not be displayed. Instead, a message will appear stating, "This interactive component isn't available on mobile."

Previous | After Fix |
--- | --- |
<video src="https://github.com/user-attachments/assets/87554cc1-cfd5-45eb-86be-51ec26392e7f" /> | <video src="https://github.com/user-attachments/assets/038adbd7-88cb-46ab-8f93-150a3e2102f0" /> | 
