### PR TITLE
fix: Xcode 16 error fix

### DIFF
--- a/Core/Core/Network/DownloadManager.swift
+++ b/Core/Core/Network/DownloadManager.swift
@@ -247,9 +247,11 @@ public class DownloadManager: DownloadManagerProtocol {
     // MARK: - Intents
 
     public func isLargeVideosSize(blocks: [CourseBlock]) -> Bool {
-        (blocks.reduce(0) {
-            $0 + Double($1.encodedVideo?.video(downloadQuality: downloadQuality)?.fileSize ?? 0)
-        } / 1024 / 1024 / 1024) > 1
+        var totalSize: Int = 0
+        blocks.forEach { block in
+            totalSize += block.encodedVideo?.video(downloadQuality: downloadQuality)?.fileSize ?? 0
+        }
+        return totalSize / (1024 * 1024 * 1024) > 1
     }
 
     public func getDownloadTasks() async -> [DownloadDataTask] {


### PR DESCRIPTION
This PR solves next Xcode 16 compile error: `The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions`\
<br/>
<img width="1210" alt="Screenshot 2024-09-30 at 12 21 56" src="https://github.com/user-attachments/assets/eed6b854-320c-45a2-a913-3a9e4c0c09b1">
