### PR TITLE
chore: improve the logic of video stream priority

### DIFF
--- a/Core/Core/Domain/Model/CourseBlockModel.swift
+++ b/Core/Core/Domain/Model/CourseBlockModel.swift
@@ -406,44 +406,50 @@ public struct CourseBlockEncodedVideo {
     public func video(streamingQuality: StreamingQuality) -> CourseBlockVideo? {
         switch streamingQuality {
         case .auto:
-            [mobileLow, mobileHigh, desktopMP4, fallback, hls]
+            [mobileLow, mobileHigh, desktopMP4, fallback, hls, youtube]
                 .compactMap { $0 }
                 .sorted(by: { ($0?.streamPriority ?? 0) < ($1?.streamPriority ?? 0) })
                 .first?
                 .flatMap { $0 }
         case .high:
-            [desktopMP4, mobileHigh, mobileLow, fallback, hls]
+            [desktopMP4, mobileHigh, mobileLow, hls, youtube, fallback]
                 .compactMap { $0 }
                 .first?
                 .flatMap { $0 }
         case .medium:
-            [mobileHigh, mobileLow, desktopMP4, fallback, hls]
+            [mobileHigh, mobileLow, desktopMP4, hls, youtube, fallback]
                 .compactMap { $0 }
                 .first?
                 .flatMap { $0 }
         case .low:
-            [mobileLow, mobileHigh, desktopMP4, fallback, hls]
+            [mobileLow, mobileHigh, desktopMP4, hls, youtube, fallback]
                 .compactMap { $0 }
                 .first(where: { $0?.isDownloadable == true })?
                 .flatMap { $0 }
         }
     }
+}
 
-    public var youtubeVideoUrl: String? {
-        youtube?.url
-    }
-
+public enum CourseBlockVideoEncoding {
+    case mobileLow, mobileHigh, desktopMP4, fallback, hls, youtube
 }
 
 public struct CourseBlockVideo: Equatable {
     public let url: String?
     public let fileSize: Int?
     public let streamPriority: Int?
+    public let type: CourseBlockVideoEncoding?
 
-    public init(url: String?, fileSize: Int?, streamPriority: Int?) {
+    public init(
+        url: String?,
+        fileSize: Int?,
+        streamPriority: Int?,
+        type: CourseBlockVideoEncoding?
+    ) {
         self.url = url
         self.fileSize = fileSize
         self.streamPriority = streamPriority
+        self.type = type
     }
 
     public var isVideoURL: Bool {

--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -40,7 +40,7 @@ public class CourseRepository: CourseRepositoryProtocol {
         self.config = config
         self.persistence = persistence
     }
-        
+    
     public func getCourseBlocks(courseID: String) async throws -> CourseStructure {
         let course = try await api.requestData(
             CourseEndpoint.getCourseBlocks(courseID: courseID, userName: coreStorage.user?.username ?? "")
@@ -245,7 +245,7 @@ public class CourseRepository: CourseRepositoryProtocol {
                 .replacingOccurrences(of: "?lang=\($0.key)", with: "")
             return SubtitleUrl(language: $0.key, url: url)
         }
-            
+        
         return CourseBlock(
             blockId: block.blockId,
             id: block.id,
@@ -260,25 +260,44 @@ public class CourseRepository: CourseRepositoryProtocol {
             webUrl: block.webUrl,
             subtitles: subtitles,
             encodedVideo: .init(
-                fallback: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.fallback),
-                youtube: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.youTube),
-                desktopMP4: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.desktopMP4),
-                mobileHigh: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.mobileHigh),
-                mobileLow: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.mobileLow),
-                hls: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.hls)
+                fallback: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.fallback,
+                    type: .fallback
+                ),
+                youtube: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.youTube,
+                    type: .youtube
+                ),
+                desktopMP4: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.desktopMP4,
+                    type: .desktopMP4
+                ),
+                mobileHigh: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.mobileHigh,
+                    type: .mobileHigh
+                ),
+                mobileLow: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.mobileLow,
+                    type: .mobileLow
+                ),
+                hls: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.hls,
+                    type: .hls
+                )
             ),
             multiDevice: block.multiDevice
         )
     }
     
-    private func parseVideo(encodedVideo: DataLayer.EncodedVideoData?) -> CourseBlockVideo? {
+    private func parseVideo(encodedVideo: DataLayer.EncodedVideoData?, type: CourseBlockVideoEncoding) -> CourseBlockVideo? {
         guard let encodedVideo, encodedVideo.url?.isEmpty == false else {
             return nil
         }
         return .init(
             url: encodedVideo.url,
             fileSize: encodedVideo.fileSize,
-            streamPriority: encodedVideo.streamPriority
+            streamPriority: encodedVideo.streamPriority,
+            type: type
         )
     }
 }
@@ -512,25 +531,45 @@ And there are various ways of describing it-- call it oral poetry or
             webUrl: block.webUrl,
             subtitles: subtitles,
             encodedVideo: .init(
-                fallback: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.fallback),
-                youtube: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.youTube),
-                desktopMP4: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.desktopMP4),
-                mobileHigh: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.mobileHigh),
-                mobileLow: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.mobileLow),
-                hls: parseVideo(encodedVideo: block.userViewData?.encodedVideo?.hls)
+                fallback: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.fallback,
+                    type: .fallback
+                ),
+                youtube: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.youTube,
+                    type: .youtube
+                ),
+                desktopMP4: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.desktopMP4,
+                    type: .desktopMP4
+                ),
+                mobileHigh: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.mobileHigh,
+                    type: .mobileHigh
+                ),
+                mobileLow: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.mobileLow, type: .mobileLow),
+                hls: parseVideo(
+                    encodedVideo: block.userViewData?.encodedVideo?.hls,
+                    type: .hls
+                )
             ),
             multiDevice: block.multiDevice
         )
     }
 
-    private func parseVideo(encodedVideo: DataLayer.EncodedVideoData?) -> CourseBlockVideo? {
+    private func parseVideo(
+        encodedVideo: DataLayer.EncodedVideoData?,
+        type: CourseBlockVideoEncoding
+    ) -> CourseBlockVideo? {
         guard let encodedVideo else {
             return nil
         }
         return .init(
             url: encodedVideo.url,
             fileSize: encodedVideo.fileSize,
-            streamPriority: encodedVideo.streamPriority
+            streamPriority: encodedVideo.streamPriority,
+            type: type
         )
     }
 }

--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -289,7 +289,10 @@ public class CourseRepository: CourseRepositoryProtocol {
         )
     }
     
-    private func parseVideo(encodedVideo: DataLayer.EncodedVideoData?, type: CourseBlockVideoEncoding) -> CourseBlockVideo? {
+    private func parseVideo(
+        encodedVideo: DataLayer.EncodedVideoData?,
+        type: CourseBlockVideoEncoding
+    ) -> CourseBlockVideo? {
         guard let encodedVideo, encodedVideo.url?.isEmpty == false else {
             return nil
         }

--- a/Course/Course/Presentation/Unit/CourseUnitViewModel.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitViewModel.swift
@@ -31,13 +31,15 @@ public enum LessonType: Equatable {
         case .discussion:
             return .discussion(block.topicId ?? "", block.id, block.displayName)
         case .video:
-            if block.encodedVideo?.youtubeVideoUrl != nil,
-                let encodedVideo = block.encodedVideo?.video(streamingQuality: streamingQuality)?.url {
-                return .video(videoUrl: encodedVideo, blockID: block.id)
-            } else if let youtubeVideoUrl = block.encodedVideo?.youtubeVideoUrl {
-                return .youtube(youtubeVideoUrl: youtubeVideoUrl, blockID: block.id)
-            } else if let encodedVideo = block.encodedVideo?.video(streamingQuality: streamingQuality)?.url {
-                return .video(videoUrl: encodedVideo, blockID: block.id)
+            if let encodedVideo = block.encodedVideo?.video(streamingQuality: streamingQuality),
+               let videoURL = encodedVideo.url {
+                if encodedVideo.type == .youtube {
+                    return .youtube(youtubeVideoUrl: videoURL, blockID: block.id)
+                } else if encodedVideo.isVideoURL {
+                    return .video(videoUrl: videoURL, blockID: block.id)
+                } else {
+                    return .unknown(block.studentUrl)
+                }
             } else {
                 return .unknown(block.studentUrl)
             }

--- a/Course/CourseTests/Presentation/Container/CourseContainerViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Container/CourseContainerViewModelTests.swift
@@ -395,7 +395,7 @@ final class CourseContainerViewModelTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1, type: .desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil
@@ -542,7 +542,7 @@ final class CourseContainerViewModelTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1, type: .desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil
@@ -673,7 +673,7 @@ final class CourseContainerViewModelTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1, type: .desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil
@@ -805,7 +805,7 @@ final class CourseContainerViewModelTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1, type:.desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil
@@ -931,7 +931,7 @@ final class CourseContainerViewModelTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1, type:.desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil
@@ -1072,7 +1072,7 @@ final class CourseContainerViewModelTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1, type:.desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil
@@ -1212,7 +1212,7 @@ final class CourseContainerViewModelTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1, type:.desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil
@@ -1234,7 +1234,7 @@ final class CourseContainerViewModelTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "test.mp4", fileSize: 1000, streamPriority: 1, type:.desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil


### PR DESCRIPTION
### Description
Jira Ticket: [LEARNER-10243](https://2u-internal.atlassian.net/browse/LEARNER-10243)

This PR improves the logic of streaming videos:

- If the auto preference is selected in settings for streaming videos, then the server returned `stream_priority` is used to pick the URL for streaming.
- If any other preference is selected for streaming videos, then the predefined (hardcoded in codebase list) is used to pick the URL for streaming. 