### PR TITLE
chore: show subtitles for videos in full-screen mode

### DIFF
--- a/Course/Course/Presentation/Video/EncodedVideoPlayer.swift
+++ b/Course/Course/Presentation/Video/EncodedVideoPlayer.swift
@@ -28,6 +28,7 @@ public struct EncodedVideoPlayer: View {
     @State private var isLoading: Bool = true
     @State private var isAnimating: Bool = false
     @State private var isOrientationChanged: Bool = false
+    @State private var subtitleText: String = ""
     
     @State var showAlert = false
     @State var alertMessage: String? {
@@ -54,7 +55,10 @@ public struct EncodedVideoPlayer: View {
                 VStack(spacing: 10) {
                     HStack {
                         VStack {
-                            PlayerViewController(playerController: viewModel.controller)
+                            PlayerViewController(
+                                playerController: viewModel.controller,
+                                subtitleText: $subtitleText
+                            )
                             .aspectRatio(16 / 9, contentMode: .fit)
                             .frame(minWidth: playerWidth(for: reader.size))
                             .cornerRadius(12)
@@ -114,6 +118,10 @@ public struct EncodedVideoPlayer: View {
         .onAppear {
             viewModel.controller.player?.allowsExternalPlayback = true
             viewModel.controller.setNeedsStatusBarAppearanceUpdate()
+        }
+        .onReceive(viewModel.$currentTime) { currentTime in
+            let subtitle = viewModel.findSubtitle(at: Date(milliseconds: currentTime))
+            subtitleText = subtitle?.text ?? ""
         }
     }
     

--- a/Course/Course/Presentation/Video/EncodedVideoPlayerViewModel.swift
+++ b/Course/Course/Presentation/Video/EncodedVideoPlayerViewModel.swift
@@ -10,7 +10,7 @@ import Core
 import Combine
 
 public class EncodedVideoPlayerViewModel: VideoPlayerViewModel {
-    var controller: AVPlayerViewController {
-        (playerHolder.playerController as? AVPlayerViewController) ?? AVPlayerViewController()
+    var controller: CustomAVPlayerViewController {
+        (playerHolder.playerController as? CustomAVPlayerViewController) ?? CustomAVPlayerViewController()
     }
 }

--- a/Course/Course/Presentation/Video/PlayerViewController.swift
+++ b/Course/Course/Presentation/Video/PlayerViewController.swift
@@ -11,9 +11,10 @@ import SwiftUI
 import _AVKit_SwiftUI
 
 struct PlayerViewController: UIViewControllerRepresentable {
-    var playerController: AVPlayerViewController
+    var playerController: CustomAVPlayerViewController
+    @Binding var subtitleText: String
 
-    func makeUIViewController(context: Context) -> AVPlayerViewController {
+    func makeUIViewController(context: Context) -> CustomAVPlayerViewController {
         do {
             try AVAudioSession.sharedInstance().setCategory(.playback)
         } catch {
@@ -23,5 +24,66 @@ struct PlayerViewController: UIViewControllerRepresentable {
         return playerController
     }
     
-    func updateUIViewController(_ playerController: AVPlayerViewController, context: Context) {}
+    func updateUIViewController(_ playerController: CustomAVPlayerViewController, context: Context) {
+        playerController.subtitleText = subtitleText
+    }
+}
+
+class CustomAVPlayerViewController: AVPlayerViewController {
+    private let subtitleLabel = UILabel()
+
+    var subtitleText: String = "" {
+        didSet {
+            subtitleLabel.text = subtitleText
+        }
+    }
+    
+    var hideSubtitle: Bool = false {
+        didSet {
+            subtitleLabel.isHidden = hideSubtitle
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Configure the subtitle label
+        subtitleLabel.textColor = .white
+        subtitleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+        subtitleLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        subtitleLabel.textAlignment = .center
+        subtitleLabel.numberOfLines = 0
+        subtitleLabel.layer.cornerRadius = 8
+        subtitleLabel.layer.masksToBounds = true
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.isHidden = true
+        
+        self.delegate = self
+
+        // Add subtitle label to the content overlay view of AVPlayerViewController
+        contentOverlayView?.addSubview(subtitleLabel)
+
+        // Set constraints for the subtitle label
+        NSLayoutConstraint.activate([
+            subtitleLabel.centerXAnchor.constraint(equalTo: contentOverlayView!.centerXAnchor),
+            subtitleLabel.bottomAnchor.constraint(equalTo: contentOverlayView!.bottomAnchor, constant: -20),
+            subtitleLabel.widthAnchor.constraint(lessThanOrEqualTo: contentOverlayView!.widthAnchor, multiplier: 0.9)
+        ])
+    }
+}
+
+extension CustomAVPlayerViewController: AVPlayerViewControllerDelegate {
+    func playerViewController(
+        _ playerViewController: AVPlayerViewController,
+        willBeginFullScreenPresentationWithAnimationCoordinator coordinator: any UIViewControllerTransitionCoordinator
+    ) {
+        hideSubtitle = false
+    }
+    
+    func playerViewController(
+        _ playerViewController: AVPlayerViewController,
+        willEndFullScreenPresentationWithAnimationCoordinator coordinator: any UIViewControllerTransitionCoordinator
+    ) {
+        hideSubtitle = true
+    }
 }

--- a/Course/Course/Presentation/Video/PlayerViewControllerHolder.swift
+++ b/Course/Course/Presentation/Video/PlayerViewControllerHolder.swift
@@ -80,7 +80,7 @@ public class PlayerViewControllerHolder: PlayerViewControllerHolderProtocol {
     let pipManager: PipManagerProtocol
 
     public lazy var playerController: PlayerControllerProtocol? = {
-        let playerController = AVPlayerViewController()
+        let playerController = CustomAVPlayerViewController()
         playerController.modalPresentationStyle = .fullScreen
         playerController.allowsPictureInPicturePlayback = true
         playerController.canStartPictureInPictureAutomaticallyFromInline = true

--- a/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
+++ b/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
@@ -266,4 +266,8 @@ public class VideoPlayerViewModel: ObservableObject {
             duration: playerHolder.duration
         )
     }
+    
+    func findSubtitle(at currentTime: Date) -> Subtitle? {
+        return subtitles.first { $0.fromTo.contains(currentTime) }
+    }
 }


### PR DESCRIPTION
[LEARNER-10236](https://2u-internal.atlassian.net/browse/LEARNER-10236): iOS - videos do not show captions when viewed full-screen

In the current implementation, subtitles are displayed only in full-screen mode, whether in landscape or portrait orientation. Subtitles are not shown in non-full-screen mode for two reasons. First, we cannot control the default caption on/off option provided by AVPlayer. Second, in normal mode, users can already view captions in any language, making it unnecessary to display additional subtitles. However, in full-screen mode, the option to view captions is unavailable, which is why we ensure subtitles are shown in that mode.

**Note:** Currently, there is no option to hide subtitles in full-screen mode. To enable this functionality, we would need to design a solution for it or opt for a fully custom implementation by hiding the default AVPlayer control bar.

Demo Downloaded Video | Demo Streaming Video |
--- | --- |
<video src="https://github.com/user-attachments/assets/036d6d67-138c-4175-be73-1fc303f80d34" /> | <video src="https://github.com/user-attachments/assets/1113bf5a-0d42-42c0-91b4-babee20338f7" /> |