### PR TITLE
fix: iOS 18 Toggle tap gesture

### DIFF
--- a/Course/Course/Presentation/Dates/CourseDatesView.swift
+++ b/Course/Course/Presentation/Dates/CourseDatesView.swift
@@ -462,9 +462,16 @@ struct CalendarSyncView: View {
                 Toggle("", isOn: .constant(viewModel.isOn))
                     .toggleStyle(SwitchToggleStyle(tint: Theme.Colors.accentButtonColor))
                     .padding(.trailing, 0)
-                    .onTapGesture {
-                        viewModel.calendarState = !viewModel.isOn
-                    }
+                    .highPriorityGesture(
+                        TapGesture().onEnded {
+                            viewModel.calendarState = !viewModel.isOn
+                        }
+                    )
+                    .highPriorityGesture(
+                        DragGesture(minimumDistance: 20, coordinateSpace: .local).onEnded { _ in
+                            viewModel.calendarState = !viewModel.isOn
+                        }
+                    )
             }
             .padding(.horizontal, 16)
             

--- a/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarView.swift
+++ b/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarView.swift
@@ -135,13 +135,15 @@ struct CourseVideoDownloadBarView: View {
         Toggle("", isOn: .constant(viewModel.isOn))
             .toggleStyle(SwitchToggleStyle(tint: Theme.Colors.toggleSwitchColor))
             .padding(.trailing, 15)
-            .onTapGesture {
-                if !viewModel.isInternetAvaliable {
-                    onNotInternetAvaliable?()
-                    return
+            .highPriorityGesture(
+                TapGesture().onEnded {
+                    if !viewModel.isInternetAvaliable {
+                        onNotInternetAvaliable?()
+                        return
+                    }
+                    Task { await viewModel.onToggle()  }
                 }
-                Task { await viewModel.onToggle()  }
-            }
+            )
             .accessibilityIdentifier("download_toggle")
     }
 }

--- a/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarView.swift
+++ b/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarView.swift
@@ -136,14 +136,23 @@ struct CourseVideoDownloadBarView: View {
             .toggleStyle(SwitchToggleStyle(tint: Theme.Colors.toggleSwitchColor))
             .padding(.trailing, 15)
             .highPriorityGesture(
+                DragGesture(minimumDistance: 20, coordinateSpace: .local).onEnded { _ in
+                    toggleAction()
+                }
+            )
+            .highPriorityGesture(
                 TapGesture().onEnded {
-                    if !viewModel.isInternetAvaliable {
-                        onNotInternetAvaliable?()
-                        return
-                    }
-                    Task { await viewModel.onToggle()  }
+                    toggleAction()
                 }
             )
             .accessibilityIdentifier("download_toggle")
+    }
+
+    private func toggleAction() {
+        if !viewModel.isInternetAvaliable {
+            onNotInternetAvaliable?()
+            return
+        }
+        Task { await viewModel.onToggle()  }
     }
 }


### PR DESCRIPTION
In iOS 18, parental view blocks the tap gesture for Toogle, and tapping only works in a small area above Toggle. Drag action doesn't work too. Added priority for the Toggle gestures (both tap and drag).

| Before | After |
| ------ | ------ |
| <video src="https://github.com/user-attachments/assets/bfe2f698-2c5b-4923-860e-53fc666e6fcb"> | <video src="https://github.com/user-attachments/assets/f92a98ac-ee23-43f4-a48d-0464dc58b1bb"> |