### PR TITLE
chore: hide grades when sub section dependents not available

### DIFF
--- a/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
+++ b/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
@@ -127,7 +127,8 @@ struct CustomDisclosureGroup: View {
                                                 VStack(alignment: .leading) {
                                                     HStack {
                                                         if sequential.completion == 1 {
-                                                            CoreAssets.finishedSequence.swiftUIImage.renderingMode(.template)
+                                                            CoreAssets.finishedSequence.swiftUIImage
+                                                                .renderingMode(.template)
                                                                 .resizable()
                                                                 .foregroundColor(Theme.Colors.success)
                                                                 .frame(width: 20, height: 20)
@@ -145,13 +146,10 @@ struct CustomDisclosureGroup: View {
                                                                 alignment: .leading
                                                             )
                                                     }
-                                                    if let sequentialProgress = sequential.sequentialProgress,
-                                                       let assignmentType = sequentialProgress.assignmentType,
-                                                       let numPointsEarned = sequentialProgress.numPointsEarned,
-                                                       let numPointsPossible = sequentialProgress.numPointsPossible,
-                                                       let due = sequential.due {
-                                                        let daysRemaining = getAssignmentStatus(for: due)
-                                                        Text("\(assignmentType) - \(daysRemaining) - \(numPointsEarned) / \(numPointsPossible)")
+                                                    if let assignmentStatusText = assignmentStatusText(
+                                                        sequential: sequential
+                                                    ) {
+                                                        Text(assignmentStatusText)
                                                             .font(Theme.Fonts.bodySmall)
                                                             .multilineTextAlignment(.leading)
                                                             .lineLimit(2)
@@ -218,9 +216,32 @@ struct CustomDisclosureGroup: View {
         }
     }
     
+    private func assignmentStatusText(
+        sequential: CourseSequential
+    ) -> String? {
+        
+        guard let sequentialProgress = sequential.sequentialProgress,
+              let assignmentType = sequentialProgress.assignmentType,
+              let numPointsEarned = sequentialProgress.numPointsEarned,
+              let numPointsPossible = sequentialProgress.numPointsPossible,
+              let due = sequential.due else {
+            return nil
+        }
+        
+        let daysRemaining = getAssignmentStatus(for: due)
+        
+        if let courseVertical = sequential.childs.first,
+           courseVertical.childs.isEmpty {
+            return "\(assignmentType) - \(daysRemaining)"
+        }
+        
+        return "\(assignmentType) - \(daysRemaining) - \(numPointsEarned) / \(numPointsPossible)"
+        
+    }
+    
     private func canDownloadAllSections(in chapter: CourseChapter) -> Bool {
         for sequential in chapter.childs {
-            if let state = viewModel.sequentialsDownloadState[sequential.id] {
+            if let _ = viewModel.sequentialsDownloadState[sequential.id] {
                 return true
             }
         }
@@ -383,7 +404,7 @@ struct CustomDisclosureGroup_Previews: PreviewProvider {
             courseStart: Date(),
             courseEnd: nil,
             enrollmentStart: Date(),
-            enrollmentEnd: nil, 
+            enrollmentEnd: nil,
             lastVisitedBlockID: nil,
             coreAnalytics: CoreAnalyticsMock(),
             serverConfig: ServerConfigProtocolMock()

--- a/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
+++ b/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
@@ -240,11 +240,10 @@ struct CustomDisclosureGroup: View {
     }
     
     private func canDownloadAllSections(in chapter: CourseChapter) -> Bool {
-        for sequential in chapter.childs {
-            if let _ = viewModel.sequentialsDownloadState[sequential.id] {
-                return true
-            }
+        for sequential in chapter.childs where viewModel.sequentialsDownloadState[sequential.id] != nil {
+            return true
         }
+        
         return false
     }
     


### PR DESCRIPTION
### Description 

[LEARNER-10266](https://2u-internal.atlassian.net/browse/LEARNER-10266)

Hide the mid-term exam grading when descents aren't available and remove some warnings those were appearing in the file.

| Before  | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-28 at 11 14 46](https://github.com/user-attachments/assets/e4f7aca0-2e8d-4e6c-8166-c477cca273b3) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-28 at 10 41 59](https://github.com/user-attachments/assets/172ffadf-bbc6-40e6-bcd5-373a52de6004) |




