### PR TITLE
chore: hide progress points from assignment status

### DIFF
--- a/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
+++ b/Course/Course/Presentation/Subviews/CustomDisclosureGroup.swift
@@ -222,21 +222,13 @@ struct CustomDisclosureGroup: View {
         
         guard let sequentialProgress = sequential.sequentialProgress,
               let assignmentType = sequentialProgress.assignmentType,
-              let numPointsEarned = sequentialProgress.numPointsEarned,
-              let numPointsPossible = sequentialProgress.numPointsPossible,
               let due = sequential.due else {
             return nil
         }
         
         let daysRemaining = getAssignmentStatus(for: due)
         
-        if let courseVertical = sequential.childs.first,
-           courseVertical.childs.isEmpty {
-            return "\(assignmentType) - \(daysRemaining)"
-        }
-        
-        return "\(assignmentType) - \(daysRemaining) - \(numPointsEarned) / \(numPointsPossible)"
-        
+        return "\(assignmentType) - \(daysRemaining)"
     }
     
     private func canDownloadAllSections(in chapter: CourseChapter) -> Bool {


### PR DESCRIPTION
Description
[LEARNER-10266](https://2u-internal.atlassian.net/browse/LEARNER-10266)

We'd hide the progress points when the descendants of a subsection aren't available under this PR: https://github.com/edx/edx-mobile-marketplace-ios/pull/99. It turns out, in the case of the verified track, the server is returning all the descendants, and the instructor still has an option to hide the progress points.

At the moment, the server is not returning that information in the blocks API, so for the time being, to address the CR, we are hiding progress points altogether. We will bring them back when the server starts sending the progress hide/show boolean in the blocks API.
