### PR TITLE
refactor: change the microsoft key name in the script

### DIFF
--- a/config_script/process_config.py
+++ b/config_script/process_config.py
@@ -240,7 +240,7 @@ class ConfigurationManager:
 
     def add_microsoft_config(self, config, plist):
         microsoft = config.get('MICROSOFT', {})
-        key = microsoft.get('APP_ID')
+        key = microsoft.get('CLIENT_ID')
 
         if key:
             bundle_identifier = self.plist_manager.get_bundle_identifier()


### PR DESCRIPTION
The microsft config key name was changed in the codebase in the PR PR https://github.com/edx/edx-mobile-marketplace-ios/pull/96. This PR made the change in the config script. 