### PR TITLE
chore: log push notification status

### DIFF
--- a/Core/Core/Analytics/CoreAnalytics.swift
+++ b/Core/Core/Analytics/CoreAnalytics.swift
@@ -444,7 +444,7 @@ public enum EventBIValue: String {
     case discussionFollowToggle = "edx.bi.app.discussion.follow_toggle"
     case discussionLikeToggle = "edx.bi.app.discussion.like_toggle"
     case discussionReportToggle = "edx.bi.app.discussion.report_toggle"
-    case notificationSettingPermissionStatus = "edx.bi.app.notification.permission_settings.status"
+    case notificationSettingPermissionStatus = "edx.bi.app.notification.setting_permission.status"
 }
 
 public struct EventParamKey {

--- a/Core/Core/Analytics/CoreAnalytics.swift
+++ b/Core/Core/Analytics/CoreAnalytics.swift
@@ -331,6 +331,7 @@ public enum AnalyticsEvent: String {
     case discussionFollowToggle = "Dicussion:Post Follow Toggle"
     case discussionLikeToggle = "Discussion:Like Toggle"
     case discussionReportToggle = "Discussion:Report Toggle"
+    case notificationSettingPermissionStatus = "Notification:Setting Permission Status"
     
 }
 
@@ -443,6 +444,7 @@ public enum EventBIValue: String {
     case discussionFollowToggle = "edx.bi.app.discussion.follow_toggle"
     case discussionLikeToggle = "edx.bi.app.discussion.like_toggle"
     case discussionReportToggle = "edx.bi.app.discussion.report_toggle"
+    case notificationSettingPermissionStatus = "edx.bi.app.notification.permission_settings.status"
 }
 
 public struct EventParamKey {
@@ -501,6 +503,7 @@ public struct EventParamKey {
     public static let like = "like"
     public static let report = "report"
     public static let discussionType = "discussion_type"
+    public static let status = "status"
 }
 
 public struct EventCategory {

--- a/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
+++ b/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
@@ -210,6 +210,16 @@ class AnalyticsManager: AuthorizationAnalytics,
         trackScreenEvent(.mainDashboardProgramsClicked, biValue: .mainDashboardProgramsClicked)
     }
     
+    public func notificationPermissionStatus(status: String) {
+        trackEvent(
+            .notificationSettingPermissionStatus,
+            biValue: .notificationSettingPermissionStatus,
+            parameters: [
+                EventParamKey.status: status
+            ]
+        )
+    }
+    
     // MARK: Discovery
     
     public func discoverySearchBarClicked() {

--- a/OpenEdX/Managers/AnalyticsManager/MainScreenAnalytics.swift
+++ b/OpenEdX/Managers/AnalyticsManager/MainScreenAnalytics.swift
@@ -15,6 +15,7 @@ public protocol MainScreenAnalytics {
     func mainProgramsTabClicked()
     func mainCoursesClicked()
     func mainProgramsClicked()
+    func notificationPermissionStatus(status: String)
 }
 
 #if DEBUG
@@ -25,5 +26,6 @@ public class MainScreenAnalyticsMock: MainScreenAnalytics {
     public func mainProgramsTabClicked() {}
     public func mainProgramsClicked() {}
     public func mainCoursesClicked() {}
+    public func notificationPermissionStatus(status: String) {}
 }
 #endif

--- a/OpenEdX/View/MainScreenViewModel.swift
+++ b/OpenEdX/View/MainScreenViewModel.swift
@@ -36,7 +36,10 @@ final class MainScreenViewModel: ObservableObject {
         self.profileInteractor = profileInteractor
         self.sourceScreen = sourceScreen
         addObservers()
-        
+        trackSettingPermissionStatus()
+    }
+    
+    private func trackSettingPermissionStatus() {
         UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { (settings) in
             if settings.authorizationStatus == .notDetermined {
                 analytics.notificationPermissionStatus(status: "notDetermined")

--- a/OpenEdX/View/MainScreenViewModel.swift
+++ b/OpenEdX/View/MainScreenViewModel.swift
@@ -42,7 +42,7 @@ final class MainScreenViewModel: ObservableObject {
     private func trackSettingPermissionStatus() {
         UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { (settings) in
             if settings.authorizationStatus == .notDetermined {
-                analytics.notificationPermissionStatus(status: "notDetermined")
+                analytics.notificationPermissionStatus(status: "not_determined")
             } else if settings.authorizationStatus == .denied {
                 analytics.notificationPermissionStatus(status: "denied")
             } else if settings.authorizationStatus == .authorized {

--- a/OpenEdX/View/MainScreenViewModel.swift
+++ b/OpenEdX/View/MainScreenViewModel.swift
@@ -10,6 +10,7 @@ import Core
 import Profile
 import Combine
 import Authorization
+import UserNotifications
 
 final class MainScreenViewModel: ObservableObject {
 
@@ -35,6 +36,16 @@ final class MainScreenViewModel: ObservableObject {
         self.profileInteractor = profileInteractor
         self.sourceScreen = sourceScreen
         addObservers()
+        
+        UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { (settings) in
+            if settings.authorizationStatus == .notDetermined {
+                analytics.notificationPermissionStatus(status: "notDetermined")
+            } else if settings.authorizationStatus == .denied {
+                analytics.notificationPermissionStatus(status: "denied")
+            } else if settings.authorizationStatus == .authorized {
+                analytics.notificationPermissionStatus(status: "authorized")
+            }
+        })
     }
     
     private func addObservers() {

--- a/OpenEdX/View/MainScreenViewModel.swift
+++ b/OpenEdX/View/MainScreenViewModel.swift
@@ -40,13 +40,13 @@ final class MainScreenViewModel: ObservableObject {
     }
     
     private func trackSettingPermissionStatus() {
-        UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { (settings) in
+        UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { [weak self] (settings) in
             if settings.authorizationStatus == .notDetermined {
-                analytics.notificationPermissionStatus(status: "not_determined")
+                self?.analytics.notificationPermissionStatus(status: "not_determined")
             } else if settings.authorizationStatus == .denied {
-                analytics.notificationPermissionStatus(status: "denied")
+                self?.analytics.notificationPermissionStatus(status: "denied")
             } else if settings.authorizationStatus == .authorized {
-                analytics.notificationPermissionStatus(status: "authorized")
+                self?.analytics.notificationPermissionStatus(status: "authorized")
             }
         })
     }


### PR DESCRIPTION
### Description 

Jira: [LEARNER-10337](https://2u-internal.atlassian.net/browse/LEARNER-10337)

We need to capture the notification permission status set by the user on the Learn tab by implementing a new custom event. This event will send the current status of the permission.