### PR TITLE
fix: disabled autocapitalization for TextField

### DIFF
--- a/Core/Core/View/Base/SecureInputView.swift
+++ b/Core/Core/View/Base/SecureInputView.swift
@@ -24,6 +24,7 @@ public struct SecureInputView: View {
                     SecureField("", text: $text)
                 } else {
                     TextField("", text: $text)
+                        .autocapitalization(.none)
                 }
             }.padding(.trailing, 32)
 


### PR DESCRIPTION
Disabled autocapitalisation for TextField for password hide/unhide function.