### PR TITLE
Fix social auth banner after whats new screen

### DIFF
--- a/Authorization/Authorization/Presentation/Login/SignInViewModel.swift
+++ b/Authorization/Authorization/Presentation/Login/SignInViewModel.swift
@@ -84,7 +84,7 @@ public class SignInViewModel: ObservableObject {
             let user = try await interactor.login(username: username, password: password)
             analytics.identify(id: "\(user.id)", username: user.username, email: user.email)
             analytics.userLogin(method: .password)
-            router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen, authMethod: nil)
+            router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen, postLoginData: nil)
             NotificationCenter.default.post(name: .userAuthorized, object: nil)
         } catch let error {
             failure(error)
@@ -116,6 +116,7 @@ public class SignInViewModel: ObservableObject {
             let user = try await interactor.login(externalToken: externalToken, backend: backend)
             analytics.identify(id: "\(user.id)", username: user.username, email: user.email)
             analytics.userLogin(method: authMethod)
+            
             var socialAuthMethod: String?
             if case AuthMethod.socailAuth(let method) = authMethod {
                 socialAuthMethod = method.rawValue
@@ -124,6 +125,7 @@ public class SignInViewModel: ObservableObject {
                 sourceScreen: sourceScreen,
                 authMethod: socialAuthMethod
             )
+            router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen, postLoginData: nil)
             NotificationCenter.default.post(name: .userAuthorized, object: nil)
         } catch let error {
             failure(error, authMethod: authMethod)

--- a/Authorization/Authorization/Presentation/Login/SignInViewModel.swift
+++ b/Authorization/Authorization/Presentation/Login/SignInViewModel.swift
@@ -117,15 +117,11 @@ public class SignInViewModel: ObservableObject {
             analytics.identify(id: "\(user.id)", username: user.username, email: user.email)
             analytics.userLogin(method: authMethod)
             
-            var socialAuthMethod: String?
-            if case AuthMethod.socailAuth(let method) = authMethod {
-                socialAuthMethod = method.rawValue
+            var postLoginData: PostLoginData?
+            if case .socailAuth(let socialMethod) = authMethod {
+                postLoginData = PostLoginData(authMethod: socialMethod.rawValue, showSocialRegisterBanner: false)
             }
-            router.showMainOrWhatsNewScreen(
-                sourceScreen: sourceScreen,
-                authMethod: socialAuthMethod
-            )
-            router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen, postLoginData: nil)
+            router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen, postLoginData: postLoginData)
             NotificationCenter.default.post(name: .userAuthorized, object: nil)
         } catch let error {
             failure(error, authMethod: authMethod)

--- a/Authorization/Authorization/Presentation/Login/SignInViewModel.swift
+++ b/Authorization/Authorization/Presentation/Login/SignInViewModel.swift
@@ -116,7 +116,6 @@ public class SignInViewModel: ObservableObject {
             let user = try await interactor.login(externalToken: externalToken, backend: backend)
             analytics.identify(id: "\(user.id)", username: user.username, email: user.email)
             analytics.userLogin(method: authMethod)
-            
             var postLoginData: PostLoginData?
             if case .socailAuth(let socialMethod) = authMethod {
                 postLoginData = PostLoginData(authMethod: socialMethod.rawValue, showSocialRegisterBanner: false)

--- a/Authorization/Authorization/Presentation/Registration/SignUpViewModel.swift
+++ b/Authorization/Authorization/Presentation/Registration/SignUpViewModel.swift
@@ -202,8 +202,6 @@ public class SignUpViewModel: ObservableObject {
             var postLoginData: PostLoginData?
             if case .socailAuth(let socialMethod) = authMethod {
                 postLoginData = PostLoginData(authMethod: socialMethod.rawValue, showSocialRegisterBanner: true)
-            } else {
-                postLoginData = nil
             }
             router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen, postLoginData: postLoginData)
             NotificationCenter.default.post(name: .userAuthorized, object: nil)

--- a/Authorization/Authorization/Presentation/Registration/SignUpViewModel.swift
+++ b/Authorization/Authorization/Presentation/Registration/SignUpViewModel.swift
@@ -138,14 +138,11 @@ public class SignUpViewModel: ObservableObject {
             analytics.identify(id: "\(user.id)", username: user.username, email: user.email)
             analytics.registrationSuccess(method: authMetod.analyticsValue)
             isShowProgress = false
-            var socialAuthMethod: String?
-            if case AuthMethod.socailAuth(let method) = authMethod {
-                socialAuthMethod = method.rawValue
+            var postLoginData: PostLoginData?
+            if case .socailAuth(let socialMethod) = authMethod {
+                postLoginData = PostLoginData(authMethod: socialMethod.rawValue, showSocialRegisterBanner: false)
             }
-            router.showMainOrWhatsNewScreen(
-                sourceScreen: sourceScreen,
-                authMethod: socialAuthMethod
-            )
+            router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen, postLoginData: postLoginData)
             NotificationCenter.default.post(name: .userAuthorized, object: nil)
         } catch let error {
             isShowProgress = false
@@ -202,21 +199,14 @@ public class SignUpViewModel: ObservableObject {
             analytics.identify(id: "\(user.id)", username: user.username, email: user.email)
             analytics.userLogin(method: authMethod)
             isShowProgress = false
-            var socialAuthMethod: String? = nil
-            if case AuthMethod.socailAuth(let method) = authMethod {
-                socialAuthMethod = method.rawValue
+            var postLoginData: PostLoginData?
+            if case .socailAuth(let socialMethod) = authMethod {
+                postLoginData = PostLoginData(authMethod: socialMethod.rawValue, showSocialRegisterBanner: true)
+            } else {
+                postLoginData = nil
             }
-            router.showMainOrWhatsNewScreen(
-                sourceScreen: sourceScreen,
-                authMethod: socialAuthMethod
-            )
-            NotificationCenter.default.post(
-                name: .userAuthorized,
-                object: [
-                    "authMethod": authMethod,
-                    "showSocialRegisterBanner": true
-                    ]
-            )
+            router.showMainOrWhatsNewScreen(sourceScreen: sourceScreen, postLoginData: postLoginData)
+            NotificationCenter.default.post(name: .userAuthorized, object: nil)
         } catch {
             update(fullName: response.name, email: response.email)
             self.externalToken = response.token

--- a/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
+++ b/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
@@ -885,10 +885,10 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -1007,7 +1007,7 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -1055,10 +1055,10 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -1171,7 +1171,7 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -1199,7 +1199,7 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -1241,7 +1241,7 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -1289,8 +1289,8 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)
@@ -1498,10 +1498,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -1619,7 +1619,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -1662,10 +1662,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -1777,7 +1777,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -1804,7 +1804,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -1845,7 +1845,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -1890,8 +1890,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)

--- a/Authorization/AuthorizationTests/Presentation/Login/SignInViewModelTests.swift
+++ b/Authorization/AuthorizationTests/Presentation/Login/SignInViewModelTests.swift
@@ -40,7 +40,7 @@ final class SignInViewModelTests: XCTestCase {
         await viewModel.login(username: "", password: "")
         
         Verify(interactor, 0, .login(username: .any, password: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.errorMessage, AuthLocalization.Error.invalidEmailAddressOrUsername)
         XCTAssertEqual(viewModel.isShowProgress, false)
@@ -63,7 +63,7 @@ final class SignInViewModelTests: XCTestCase {
         await viewModel.login(username: "edxUser@edx.com", password: "")
         
         Verify(interactor, 0, .login(username: .any, password: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.errorMessage, AuthLocalization.Error.invalidPasswordLenght)
         XCTAssertEqual(viewModel.isShowProgress, false)
@@ -91,7 +91,7 @@ final class SignInViewModelTests: XCTestCase {
         
         Verify(interactor, 1, .login(username: .any, password: .any))
         Verify(analytics, .userLogin(method: .any))
-        Verify(router, 1, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 1, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.errorMessage, nil)
         XCTAssertEqual(viewModel.isShowProgress, true)
@@ -123,7 +123,7 @@ final class SignInViewModelTests: XCTestCase {
 
         Verify(interactor, 1, .login(externalToken: .any, backend: .any))
         Verify(analytics, .userLogin(method: .any))
-        Verify(router, 1, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 1, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
 
         XCTAssertEqual(viewModel.errorMessage, nil)
         XCTAssertEqual(viewModel.isShowProgress, true)
@@ -159,7 +159,7 @@ final class SignInViewModelTests: XCTestCase {
         await viewModel.login(with: result)
 
         Verify(interactor, 1, .login(externalToken: .any, backend: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
 
         XCTAssertEqual(viewModel.errorMessage, validationErrorMessage)
         XCTAssertEqual(viewModel.isShowProgress, false)
@@ -189,7 +189,7 @@ final class SignInViewModelTests: XCTestCase {
         await viewModel.login(username: "edxUser@edx.com", password: "password123")
         
         Verify(interactor, 1, .login(username: .any, password: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.errorMessage, validationErrorMessage)
         XCTAssertEqual(viewModel.isShowProgress, false)
@@ -215,7 +215,7 @@ final class SignInViewModelTests: XCTestCase {
         await viewModel.login(username: "edxUser@edx.com", password: "password123")
         
         Verify(interactor, 1, .login(username: .any, password: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.errorMessage, CoreLocalization.Error.invalidCredentials)
         XCTAssertEqual(viewModel.isShowProgress, false)
@@ -241,7 +241,7 @@ final class SignInViewModelTests: XCTestCase {
         await viewModel.login(username: "edxUser@edx.com", password: "password123")
         
         Verify(interactor, 1, .login(username: .any, password: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.errorMessage, CoreLocalization.Error.unknownError)
         XCTAssertEqual(viewModel.isShowProgress, false)
@@ -269,7 +269,7 @@ final class SignInViewModelTests: XCTestCase {
         await viewModel.login(username: "edxUser@edx.com", password: "password123")
         
         Verify(interactor, 1, .login(username: .any, password: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.errorMessage, CoreLocalization.Error.slowOrNoInternetConnection)
         XCTAssertEqual(viewModel.isShowProgress, false)

--- a/Authorization/AuthorizationTests/Presentation/Register/SignUpViewModelTests.swift
+++ b/Authorization/AuthorizationTests/Presentation/Register/SignUpViewModelTests.swift
@@ -136,7 +136,7 @@ final class SignUpViewModelTests: XCTestCase {
         
         Verify(interactor, 1, .validateRegistrationFields(fields: .any))
         Verify(interactor, 1, .registerUser(fields: .any, isSocial: .any))
-        Verify(router, 1, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 1, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.isShowProgress, false)
         XCTAssertEqual(viewModel.showError, false)
@@ -174,7 +174,7 @@ final class SignUpViewModelTests: XCTestCase {
         
         Verify(interactor, 1, .validateRegistrationFields(fields: .any))
         Verify(interactor, 0, .registerUser(fields: .any, isSocial: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.isShowProgress, false)
         XCTAssertEqual(viewModel.showError, false)
@@ -204,7 +204,7 @@ final class SignUpViewModelTests: XCTestCase {
         
         Verify(interactor, 1, .validateRegistrationFields(fields: .any))
         Verify(interactor, 1, .registerUser(fields: .any, isSocial: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.isShowProgress, false)
         XCTAssertEqual(viewModel.showError, true)
@@ -234,7 +234,7 @@ final class SignUpViewModelTests: XCTestCase {
         
         Verify(interactor, 1, .validateRegistrationFields(fields: .any))
         Verify(interactor, 1, .registerUser(fields: .any, isSocial: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.isShowProgress, false)
         XCTAssertEqual(viewModel.showError, true)
@@ -266,7 +266,7 @@ final class SignUpViewModelTests: XCTestCase {
         
         Verify(interactor, 1, .validateRegistrationFields(fields: .any))
         Verify(interactor, 1, .registerUser(fields: .any, isSocial: .any))
-        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, authMethod: .any))
+        Verify(router, 0, .showMainOrWhatsNewScreen(sourceScreen: .any, postLoginData: .any))
         
         XCTAssertEqual(viewModel.isShowProgress, false)
         XCTAssertEqual(viewModel.showError, true)

--- a/Core/Core/Configuration/BaseRouter.swift
+++ b/Core/Core/Configuration/BaseRouter.swift
@@ -21,10 +21,7 @@ public protocol BaseRouter {
     
     func removeLastView(controllers: Int)
 
-    func showMainOrWhatsNewScreen(
-        sourceScreen: LogistrationSourceScreen,
-        authMethod: String?
-    )
+    func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?)
     
     func showStartupScreen()
     
@@ -109,10 +106,7 @@ open class BaseRouterMock: BaseRouter {
 
     public func dismiss(animated: Bool) {}
 
-    public func showMainOrWhatsNewScreen(
-        sourceScreen: LogistrationSourceScreen,
-        authMethod: String?
-    ) {}
+    public func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {}
     
     public func showStartupScreen() {}
 

--- a/Core/Core/View/Base/LogistrationBottomView.swift
+++ b/Core/Core/View/Base/LogistrationBottomView.swift
@@ -27,18 +27,15 @@ public enum LogistrationAction {
 }
 
 public struct PostLoginData: Sendable {
-    public let authMethod: String
-    public var showSocialRegisterBanner: Bool
+    public var authMethod: String = ""
+    public var showSocialRegisterBanner: Bool = false
     
     public init(authMethod: String, showSocialRegisterBanner: Bool) {
         self.authMethod = authMethod
         self.showSocialRegisterBanner = showSocialRegisterBanner
     }
     
-    public init() {
-        self.authMethod = ""
-        self.showSocialRegisterBanner = false
-    }
+    public init() {}
 }
 
 public struct LogistrationBottomView: View {

--- a/Core/Core/View/Base/LogistrationBottomView.swift
+++ b/Core/Core/View/Base/LogistrationBottomView.swift
@@ -34,6 +34,11 @@ public struct PostLoginData: Sendable {
         self.authMethod = authMethod
         self.showSocialRegisterBanner = showSocialRegisterBanner
     }
+    
+    public init() {
+        self.authMethod = ""
+        self.showSocialRegisterBanner = false
+    }
 }
 
 public struct LogistrationBottomView: View {

--- a/Core/Core/View/Base/LogistrationBottomView.swift
+++ b/Core/Core/View/Base/LogistrationBottomView.swift
@@ -26,6 +26,16 @@ public enum LogistrationAction {
     case register
 }
 
+public struct PostLoginData: Sendable {
+    public let authMethod: String
+    public var showSocialRegisterBanner: Bool
+    
+    public init(authMethod: String, showSocialRegisterBanner: Bool) {
+        self.authMethod = authMethod
+        self.showSocialRegisterBanner = showSocialRegisterBanner
+    }
+}
+
 public struct LogistrationBottomView: View {
     private let action: (LogistrationAction) -> Void
     

--- a/Course/CourseTests/CourseMock.generated.swift
+++ b/Course/CourseTests/CourseMock.generated.swift
@@ -539,10 +539,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -660,7 +660,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -703,10 +703,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -818,7 +818,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -845,7 +845,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -886,7 +886,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -931,8 +931,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)

--- a/Dashboard/DashboardTests/DashboardMock.generated.swift
+++ b/Dashboard/DashboardTests/DashboardMock.generated.swift
@@ -539,10 +539,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -660,7 +660,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -703,10 +703,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -818,7 +818,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -845,7 +845,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -886,7 +886,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -931,8 +931,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)

--- a/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
+++ b/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
@@ -539,10 +539,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -660,7 +660,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -703,10 +703,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -818,7 +818,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -845,7 +845,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -886,7 +886,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -931,8 +931,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)

--- a/Discussion/DiscussionTests/DiscussionMock.generated.swift
+++ b/Discussion/DiscussionTests/DiscussionMock.generated.swift
@@ -539,10 +539,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -660,7 +660,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -703,10 +703,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -818,7 +818,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -845,7 +845,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -886,7 +886,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -931,8 +931,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)
@@ -3880,10 +3880,10 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -4007,7 +4007,7 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -4096,10 +4096,10 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -4217,7 +4217,7 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -4250,7 +4250,7 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -4297,7 +4297,7 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -4360,8 +4360,8 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)

--- a/Notifications/NotificationsTests/NotificationsMock.generated.swift
+++ b/Notifications/NotificationsTests/NotificationsMock.generated.swift
@@ -539,10 +539,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -660,7 +660,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -703,10 +703,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -818,7 +818,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -845,7 +845,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -886,7 +886,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -931,8 +931,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -35,7 +35,7 @@ class ScreenAssembly: Assembly {
         }
         
         // MARK: MainScreenView
-        container.register(MainScreenViewModel.self) { @MainActor r, sourceScreen, postLoginData in
+        container.register(MainScreenViewModel.self) { r, sourceScreen, postLoginData in
             MainScreenViewModel(
                 analytics: r.resolve(MainScreenAnalytics.self)!,
                 config: r.resolve(ConfigProtocol.self)!,

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -35,12 +35,13 @@ class ScreenAssembly: Assembly {
         }
         
         // MARK: MainScreenView
-        container.register(MainScreenViewModel.self) { r, sourceScreen in
+        container.register(MainScreenViewModel.self) { @MainActor r, sourceScreen, postLoginData in
             MainScreenViewModel(
                 analytics: r.resolve(MainScreenAnalytics.self)!,
                 config: r.resolve(ConfigProtocol.self)!,
                 profileInteractor: r.resolve(ProfileInteractorProtocol.self)!,
-                sourceScreen: sourceScreen
+                sourceScreen: sourceScreen,
+                postLoginData: postLoginData
             )
         }
         // MARK: Startup screen

--- a/OpenEdX/RouteController.swift
+++ b/OpenEdX/RouteController.swift
@@ -91,9 +91,11 @@ class RouteController: UIViewController {
             let controller = UIHostingController(rootView: whatsNewView)
             navigation.viewControllers = [controller]
         } else {
+            let postLoginDataDefault: PostLoginData? = PostLoginData()
             let viewModel = Container.shared.resolve(
                 MainScreenViewModel.self,
-                argument: LogistrationSourceScreen.default
+                arguments: LogistrationSourceScreen.default,
+                postLoginDataDefault
             )!
             let controller = UIHostingController(rootView: MainScreenView(viewModel: viewModel))
             navigation.viewControllers = [controller]

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -71,10 +71,7 @@ public class Router: AuthorizationRouter,
         navigationController.setViewControllers(viewControllers, animated: true)
     }
     
-    public func showMainOrWhatsNewScreen(
-        sourceScreen: LogistrationSourceScreen,
-        authMethod: String?
-    ) {
+    public func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
         showToolBar()
         var whatsNewStorage = Container.shared.resolve(WhatsNewStorage.self)!
         let config = Container.shared.resolve(ConfigProtocol.self)!
@@ -90,7 +87,12 @@ public class Router: AuthorizationRouter,
             coreStorage.lastUsedSocialAuth = authMethod
         }
 
-        let viewModel = WhatsNewViewModel(storage: whatsNewStorage, sourceScreen: sourceScreen, analytics: analytics)
+        let viewModel = WhatsNewViewModel(
+            storage: whatsNewStorage,
+            sourceScreen: sourceScreen,
+            analytics: analytics,
+            postLoginData: postLoginData
+        )
         let whatsNew = WhatsNewView(router: Container.shared.resolve(WhatsNewRouter.self)!, viewModel: viewModel)
         let shouldShowWhatsNew = viewModel.shouldShowWhatsNew()
                
@@ -104,7 +106,8 @@ public class Router: AuthorizationRouter,
         } else {
             let viewModel = Container.shared.resolve(
                 MainScreenViewModel.self,
-                argument: sourceScreen
+                arguments: sourceScreen,
+                postLoginData
             )!
             
             let controller = UIHostingController(rootView: MainScreenView(viewModel: viewModel))

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -83,7 +83,7 @@ public class Router: AuthorizationRouter,
             persistence.set(userId: userId)
         }
         
-        if let authMethod = authMethod {
+        if let authMethod = postLoginData?.authMethod {
             coreStorage.lastUsedSocialAuth = authMethod
         }
 

--- a/OpenEdX/View/MainScreenViewModel.swift
+++ b/OpenEdX/View/MainScreenViewModel.swift
@@ -18,24 +18,22 @@ final class MainScreenViewModel: ObservableObject {
     let config: ConfigProtocol
     let profileInteractor: ProfileInteractorProtocol
     var sourceScreen: LogistrationSourceScreen
-
+    private var postLoginData: PostLoginData?
+    
     @Published var selection: MainTab = .dashboard
     @Published var showRegisterBanner: Bool = false
-
-    private var shouldShowRegisterBanner: Bool = false
-    private var authMethod: AuthMethod?
-    private var cancellations: [AnyCancellable] = []
 
     init(analytics: MainScreenAnalytics,
          config: ConfigProtocol,
          profileInteractor: ProfileInteractorProtocol,
-         sourceScreen: LogistrationSourceScreen = .default
+         sourceScreen: LogistrationSourceScreen = .default,
+         postLoginData: PostLoginData? = nil
     ) {
         self.analytics = analytics
         self.config = config
         self.profileInteractor = profileInteractor
         self.sourceScreen = sourceScreen
-        addObservers()
+        self.postLoginData = postLoginData
         trackSettingPermissionStatus()
     }
     
@@ -51,20 +49,6 @@ final class MainScreenViewModel: ObservableObject {
         })
     }
     
-    private func addObservers() {
-        NotificationCenter.default
-            .publisher(for: .userAuthorized)
-            .sink { [weak self] object in
-                guard let self,
-                      let dict = object.object as? [String: Any],
-                      let authMethod = dict["authMethod"] as? AuthMethod
-                else { return }
-                self.shouldShowRegisterBanner = dict["showSocialRegisterBanner"] as? Bool ?? false
-                self.authMethod = authMethod
-            }
-            .store(in: &cancellations)
-    }
-
     public func select(tab: MainTab) {
         selection = tab
     }
@@ -90,20 +74,19 @@ final class MainScreenViewModel: ObservableObject {
     }
 
     public func checkIfNeedToShowRegisterBanner() {
-        if shouldShowRegisterBanner && !registerBannerText.isEmpty {
+        if postLoginData?.showSocialRegisterBanner == true && !registerBannerText.isEmpty {
             showRegisterBanner = true
         }
     }
     public func registerBannerWasShowed() {
-        shouldShowRegisterBanner = false
+        postLoginData?.showSocialRegisterBanner = false
         showRegisterBanner = false
     }
     public var registerBannerText: String {
-        guard !config.platformName.isEmpty,
-              case .socailAuth(let socialMethod) = authMethod,
-              !socialMethod.rawValue.isEmpty
+        guard let socialAuthMethodName = postLoginData?.authMethod,
+              !socialAuthMethodName.isEmpty
         else { return "" }
-        return CoreLocalization.Mainscreen.socialRegisterBanner(config.platformName, socialMethod.rawValue.capitalized)
+        return CoreLocalization.Mainscreen.socialRegisterBanner(config.platformName, socialAuthMethodName.capitalized)
     }
 
     @MainActor

--- a/Profile/ProfileTests/ProfileMock.generated.swift
+++ b/Profile/ProfileTests/ProfileMock.generated.swift
@@ -539,10 +539,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -660,7 +660,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -703,10 +703,10 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -818,7 +818,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -845,7 +845,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -886,7 +886,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -931,8 +931,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)
@@ -4318,10 +4318,10 @@ open class ProfileRouterMock: ProfileRouter, Mock {
 		perform?(`controllers`)
     }
 
-    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, authMethod: String?) {
-        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`)))
-		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<String?>.value(`authMethod`))) as? (LogistrationSourceScreen, String?) -> Void
-		perform?(`sourceScreen`, `authMethod`)
+    open func showMainOrWhatsNewScreen(sourceScreen: LogistrationSourceScreen, postLoginData: PostLoginData?) {
+        addInvocation(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`)))
+		let perform = methodPerformValue(.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>.value(`sourceScreen`), Parameter<PostLoginData?>.value(`postLoginData`))) as? (LogistrationSourceScreen, PostLoginData?) -> Void
+		perform?(`sourceScreen`, `postLoginData`)
     }
 
     open func showStartupScreen() {
@@ -4449,7 +4449,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         case m_backWithFade
         case m_dismiss__animated_animated(Parameter<Bool>)
         case m_removeLastView__controllers_controllers(Parameter<Int>)
-        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(Parameter<LogistrationSourceScreen>, Parameter<String?>)
+        case m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(Parameter<LogistrationSourceScreen>, Parameter<PostLoginData?>)
         case m_showStartupScreen
         case m_showLoginScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
         case m_showRegisterScreen__sourceScreen_sourceScreen(Parameter<LogistrationSourceScreen>)
@@ -4525,10 +4525,10 @@ open class ProfileRouterMock: ProfileRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsControllers, rhs: rhsControllers, with: matcher), lhsControllers, rhsControllers, "controllers"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let lhsSourcescreen, let lhsAuthmethod), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(let rhsSourcescreen, let rhsAuthmethod)):
+            case (.m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let lhsSourcescreen, let lhsPostlogindata), .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(let rhsSourcescreen, let rhsPostlogindata)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSourcescreen, rhs: rhsSourcescreen, with: matcher), lhsSourcescreen, rhsSourcescreen, "sourceScreen"))
-				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAuthmethod, rhs: rhsAuthmethod, with: matcher), lhsAuthmethod, rhsAuthmethod, "authMethod"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPostlogindata, rhs: rhsPostlogindata, with: matcher), lhsPostlogindata, rhsPostlogindata, "postLoginData"))
 				return Matcher.ComparisonResult(results)
 
             case (.m_showStartupScreen, .m_showStartupScreen): return .match
@@ -4650,7 +4650,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
             case .m_backWithFade: return 0
             case let .m_dismiss__animated_animated(p0): return p0.intValue
             case let .m_removeLastView__controllers_controllers(p0): return p0.intValue
-            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(p0, p1): return p0.intValue + p1.intValue
+            case let .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(p0, p1): return p0.intValue + p1.intValue
             case .m_showStartupScreen: return 0
             case let .m_showLoginScreen__sourceScreen_sourceScreen(p0): return p0.intValue
             case let .m_showRegisterScreen__sourceScreen_sourceScreen(p0): return p0.intValue
@@ -4687,7 +4687,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
             case .m_backWithFade: return ".backWithFade()"
             case .m_dismiss__animated_animated: return ".dismiss(animated:)"
             case .m_removeLastView__controllers_controllers: return ".removeLastView(controllers:)"
-            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod: return ".showMainOrWhatsNewScreen(sourceScreen:authMethod:)"
+            case .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData: return ".showMainOrWhatsNewScreen(sourceScreen:postLoginData:)"
             case .m_showStartupScreen: return ".showStartupScreen()"
             case .m_showLoginScreen__sourceScreen_sourceScreen: return ".showLoginScreen(sourceScreen:)"
             case .m_showRegisterScreen__sourceScreen_sourceScreen: return ".showRegisterScreen(sourceScreen:)"
@@ -4738,7 +4738,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         public static func backWithFade() -> Verify { return Verify(method: .m_backWithFade)}
         public static func dismiss(animated: Parameter<Bool>) -> Verify { return Verify(method: .m_dismiss__animated_animated(`animated`))}
         public static func removeLastView(controllers: Parameter<Int>) -> Verify { return Verify(method: .m_removeLastView__controllers_controllers(`controllers`))}
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`))}
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>) -> Verify { return Verify(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`))}
         public static func showStartupScreen() -> Verify { return Verify(method: .m_showStartupScreen)}
         public static func showLoginScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showLoginScreen__sourceScreen_sourceScreen(`sourceScreen`))}
         public static func showRegisterScreen(sourceScreen: Parameter<LogistrationSourceScreen>) -> Verify { return Verify(method: .m_showRegisterScreen__sourceScreen_sourceScreen(`sourceScreen`))}
@@ -4813,8 +4813,8 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         public static func removeLastView(controllers: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
             return Perform(method: .m_removeLastView__controllers_controllers(`controllers`), performs: perform)
         }
-        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, authMethod: Parameter<String?>, perform: @escaping (LogistrationSourceScreen, String?) -> Void) -> Perform {
-            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenauthMethod_authMethod(`sourceScreen`, `authMethod`), performs: perform)
+        public static func showMainOrWhatsNewScreen(sourceScreen: Parameter<LogistrationSourceScreen>, postLoginData: Parameter<PostLoginData?>, perform: @escaping (LogistrationSourceScreen, PostLoginData?) -> Void) -> Perform {
+            return Perform(method: .m_showMainOrWhatsNewScreen__sourceScreen_sourceScreenpostLoginData_postLoginData(`sourceScreen`, `postLoginData`), performs: perform)
         }
         public static func showStartupScreen(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showStartupScreen, performs: perform)

--- a/WhatsNew/WhatsNew/Presentation/WhatsNewView.swift
+++ b/WhatsNew/WhatsNew/Presentation/WhatsNewView.swift
@@ -112,7 +112,7 @@ public struct WhatsNewView: View {
                                     } else {
                                         router.showMainOrWhatsNewScreen(
                                             sourceScreen: viewModel.sourceScreen,
-                                            authMethod: nil
+                                            postLoginData: viewModel.postLoginData
                                         )
                                     }
                                     
@@ -154,7 +154,7 @@ public struct WhatsNewView: View {
                             action: {
                                 router.showMainOrWhatsNewScreen(
                                     sourceScreen: viewModel.sourceScreen,
-                                    authMethod: nil
+                                    postLoginData: viewModel.postLoginData
                                 )
                                 viewModel.logWhatsNewClose()
                             },

--- a/WhatsNew/WhatsNew/Presentation/WhatsNewViewModel.swift
+++ b/WhatsNew/WhatsNew/Presentation/WhatsNewViewModel.swift
@@ -15,15 +15,18 @@ public class WhatsNewViewModel: ObservableObject {
     private let storage: WhatsNewStorage
     var sourceScreen: LogistrationSourceScreen
     let analytics: WhatsNewAnalytics
+    let postLoginData: PostLoginData?
     
     public init(
         storage: WhatsNewStorage,
         sourceScreen: LogistrationSourceScreen = .default,
-        analytics: WhatsNewAnalytics
+        analytics: WhatsNewAnalytics,
+        postLoginData: PostLoginData? = nil
     ) {
         self.storage = storage
         self.sourceScreen = sourceScreen
         self.analytics = analytics
+        self.postLoginData = postLoginData
         newItems = loadWhatsNew()
     }
     


### PR DESCRIPTION
In the current implementation, when Whats New View is enabled, when Whats New View is displayed on first startup, the application does not show the social registered banner. This is because the notification that is sent after a successful login does not exist until the Main View is displayed.
Now we transfer the post-login data through the WhatNew Model to the MainView Model
Before | After
----- | -----
<video src="https://github.com/user-attachments/assets/df04327e-7dc9-4327-8374-3de6a31e7555" /> | <video src="https://github.com/user-attachments/assets/951af774-8d6d-4699-91dd-abde4e35850c" />

