### PR TITLE
fix: ios 18.2 Gesture Issue

### DIFF
--- a/Course/Course/Presentation/Dates/CourseDatesView.swift
+++ b/Course/Course/Presentation/Dates/CourseDatesView.swift
@@ -462,12 +462,12 @@ struct CalendarSyncView: View {
                 Toggle("", isOn: .constant(viewModel.isOn))
                     .toggleStyle(SwitchToggleStyle(tint: Theme.Colors.accentButtonColor))
                     .padding(.trailing, 0)
-                    .highPriorityGesture(
+                    .simultaneousGesture(
                         TapGesture().onEnded {
                             viewModel.calendarState = !viewModel.isOn
                         }
                     )
-                    .highPriorityGesture(
+                    .simultaneousGesture(
                         DragGesture(minimumDistance: 20, coordinateSpace: .local).onEnded { _ in
                             viewModel.calendarState = !viewModel.isOn
                         }

--- a/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarView.swift
+++ b/Course/Course/Presentation/Subviews/CourseVideoDownloadBarView/CourseVideoDownloadBarView.swift
@@ -135,12 +135,12 @@ struct CourseVideoDownloadBarView: View {
         Toggle("", isOn: .constant(viewModel.isOn))
             .toggleStyle(SwitchToggleStyle(tint: Theme.Colors.toggleSwitchColor))
             .padding(.trailing, 15)
-            .highPriorityGesture(
+            .simultaneousGesture(
                 DragGesture(minimumDistance: 20, coordinateSpace: .local).onEnded { _ in
                     toggleAction()
                 }
             )
-            .highPriorityGesture(
+            .simultaneousGesture(
                 TapGesture().onEnded {
                     toggleAction()
                 }


### PR DESCRIPTION
Issue from https://github.com/edx/edx-mobile-marketplace-ios/pull/98 came back with iOS 18.2.
To fix this issue I changed `highPriorityGesture` to `simultaneousGesture` to prevent interception from parent view side