### PR TITLE
feat: support elevated tab bar on ipad os 18

### DIFF
--- a/Discovery/Discovery/Presentation/WebDiscovery/DiscoveryWebview.swift
+++ b/Discovery/Discovery/Presentation/WebDiscovery/DiscoveryWebview.swift
@@ -33,6 +33,7 @@ public struct DiscoveryWebview: View {
     
     @StateObject private var viewModel: DiscoveryWebviewViewModel
     private var router: DiscoveryRouter
+    private var supportsElevatedTabBar: Bool
     private var discoveryType: DiscoveryWebviewType
     public var pathID: String
     
@@ -77,12 +78,14 @@ public struct DiscoveryWebview: View {
     public init(
         viewModel: DiscoveryWebviewViewModel,
         router: DiscoveryRouter,
+        supportsElevatedTabBar: Bool,
         searchQuery: String? = nil,
         discoveryType: DiscoveryWebviewType = .discovery,
         pathID: String = ""
     ) {
         self._viewModel = .init(wrappedValue: viewModel)
         self.router = router
+        self.supportsElevatedTabBar = supportsElevatedTabBar
         self._searchQuery = State<String>(initialValue: searchQuery ?? "")
         self.discoveryType = discoveryType
         self.pathID = pathID
@@ -162,8 +165,11 @@ public struct DiscoveryWebview: View {
                 }
             }
         }
-        .hideNavigationBar(viewModel.sourceScreen == .default && discoveryType == .discovery)
-        .navigationTitle(CoreLocalization.Mainscreen.discovery)
+        .hideNavigationBar(
+            supportsElevatedTabBar ? false :
+                (viewModel.sourceScreen == .default && discoveryType == .discovery)
+        )
+        .navigationTitle(supportsElevatedTabBar ? "" : CoreLocalization.Mainscreen.discovery)
         .background(Theme.Colors.background.ignoresSafeArea())
         .onFirstAppear {
             if case let .courseDetail(pathID, _) = viewModel.sourceScreen {

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -266,6 +266,7 @@ public class Router: AuthorizationRouter,
                 DiscoveryWebviewViewModel.self,
                 argument: sourceScreen)!,
             router: Container.shared.resolve(DiscoveryRouter.self)!,
+            supportsElevatedTabBar: false,
             discoveryType: discoveryType,
             pathID: pathID
         )
@@ -316,6 +317,7 @@ public class Router: AuthorizationRouter,
                     argument: sourceScreen
                 )!,
                 router: Container.shared.resolve(DiscoveryRouter.self)!,
+                supportsElevatedTabBar: false,
                 searchQuery: searchQuery
             )
             

--- a/Profile/Profile/Presentation/Profile/ProfileView.swift
+++ b/Profile/Profile/Presentation/Profile/ProfileView.swift
@@ -13,9 +13,14 @@ import Theme
 public struct ProfileView: View {
     
     @StateObject private var viewModel: ProfileViewModel
+    private var supportsElevatedTabBar: Bool
     
-    public init(viewModel: ProfileViewModel) {
+    public init(
+        viewModel: ProfileViewModel,
+        supportsElevatedTabBar: Bool = false
+    ) {
         self._viewModel = StateObject(wrappedValue: { viewModel }())
+        self.supportsElevatedTabBar = supportsElevatedTabBar
     }
     
     public var body: some View {
@@ -35,7 +40,7 @@ public struct ProfileView: View {
                 .padding(.top, 8)
                 .hideNavigationBar(false)
                 .navigationBarBackButtonHidden(false)
-                .navigationTitle(ProfileLocalization.title)
+                .navigationTitle(supportsElevatedTabBar ? "" : ProfileLocalization.title)
                 
                 // MARK: - Offline mode SnackBar
                 OfflineSnackBarView(


### PR DESCRIPTION
Ticket: [LEARNER-10376](https://2u-internal.atlassian.net/browse/LEARNER-10376)

Added support for elevated tab bar on ipad os 18. This has been achieved by putting the tab screen inside `NavigationStack`. The relevant tweaks have been made to ensure that the look and feel remains the same on configurations where the tab bar is shown at the bottom such as in split view mode.

## iPad OS 18
| Before  | After | Split View Mode |
| ------- | ----- | ---------------- |
| ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2024-12-31 at 14 45 41](https://github.com/user-attachments/assets/3f191d10-6765-4c2a-8e7b-1a9561d8cb0e) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-01-06 at 12 47 14](https://github.com/user-attachments/assets/de738fc9-4b65-4c20-8a9c-a68f6c696573) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-01-10 at 12 42 36](https://github.com/user-attachments/assets/ffcb1b4b-6b22-4cfc-b3b0-9df7f9779fc4) |

## iPad OS ≤ 17
The behaviour will be the same on older versions of the OS.

| Full Screen Mode | Split View Mode |
| ----------------- | ---------------- |
| ![Simulator Screenshot - iPad (10th generation) - 2025-01-10 at 15 05 22](https://github.com/user-attachments/assets/f89a1580-0732-4c63-96d3-245e142acb58) | ![Simulator Screenshot - iPad (10th generation) - 2025-01-10 at 15 05 52](https://github.com/user-attachments/assets/885d736f-6767-4136-a59b-daccf102e830) |
