### PR TITLE
fix: dismiss download status bottom sheet when all downloads are done

### DIFF
--- a/Course/Course/Presentation/Downloads/DownloadsView.swift
+++ b/Course/Course/Presentation/Downloads/DownloadsView.swift
@@ -71,6 +71,9 @@ public struct DownloadsView: View {
                     dismiss()
                 }
                 .padding(.top, isSheet ? 0 : 40)
+                .onChange(of: viewModel.shouldDismiss) { _ in
+                    dismiss()
+                }
         }
     }
 

--- a/Course/Course/Presentation/Downloads/DownloadsViewModel.swift
+++ b/Course/Course/Presentation/Downloads/DownloadsViewModel.swift
@@ -14,6 +14,7 @@ final class DownloadsViewModel: ObservableObject {
     // MARK: - Properties
 
     @Published private(set) var downloads: [DownloadDataTask] = []
+    @Published private(set) var shouldDismiss: Bool = false
     private let courseId: String?
     
     let router: CourseRouter
@@ -80,6 +81,10 @@ final class DownloadsViewModel: ObservableObject {
                     }
                 case .finished(let downloadData):
                     downloads.removeAll(where: { $0.id == downloadData.id })
+                    
+                    if downloads.isEmpty {
+                        shouldDismiss = true
+                    }
                 default:
                     break
                 }


### PR DESCRIPTION
[LEARNER-10315](https://2u-internal.atlassian.net/browse/LEARNER-10315): iOS - Dismiss download status bottom sheet when all downloads are done