### PR TITLE
fix: subtitle syncing issues

### DIFF
--- a/Course/Course/Presentation/Video/SubtitlesView.swift
+++ b/Course/Course/Presentation/Video/SubtitlesView.swift
@@ -78,21 +78,8 @@ public struct SubtitlesView: View {
                                             .foregroundColor(subtitle.fromTo.contains(Date(milliseconds: currentTime))
                                                              ? Theme.Colors.accentButtonColor
                                                              : Theme.Colors.textPrimary)
-                                            
-                                            .onChange(of: currentTime, perform: { _ in
-                                                if subtitle.fromTo.contains(Date(milliseconds: currentTime)) {
-                                                    self.id = subtitle.id
-                                                }
-                                            })
                                         })
                                     }.id(subtitle.id)
-                                }
-                            }
-                            .onChange(of: id) { _ in
-                                withAnimation {
-                                    if !pause {
-                                        scroll.scrollTo(id, anchor: .top)
-                                    }
                                 }
                             }
                         }
@@ -103,6 +90,16 @@ public struct SubtitlesView: View {
                             autoScrollPublisher.send()
                         })
                     )
+                    .onChange(of: currentTime) { _ in
+                        refreshID()
+                    }
+                    .onChange(of: id) { newID in
+                        if !pause {
+                            withAnimation {
+                                scroll.scrollTo(newID, anchor: .top)
+                            }
+                        }
+                    }
                     .onReceive(autoScrollPublisher.debounce(for: .seconds(3), scheduler: DispatchQueue.main)) { _ in
                         if pause {
                             refreshID()
@@ -117,14 +114,9 @@ public struct SubtitlesView: View {
     }
     
     private func refreshID() {
-        if let subtitle = subtitle(at: currentTime) {
+        if let subtitle = viewModel.findSubtitle(at: Date(milliseconds: currentTime)) {
             id = subtitle.id
         }
-    }
-    
-    private func subtitle(at time: Double) -> Subtitle? {
-        let date = Date(milliseconds: time)
-        return viewModel.subtitles.first { $0.fromTo.contains(date) }
     }
 }
 

--- a/Course/Course/Presentation/Video/SubtitlesView.swift
+++ b/Course/Course/Presentation/Video/SubtitlesView.swift
@@ -93,9 +93,14 @@ public struct SubtitlesView: View {
                     .onChange(of: currentTime) { _ in
                         refreshID()
                     }
+                    .onChange(of: viewModel.isPlaying) { isPlaying in
+                        if !pause && isPlaying {
+                            scroll.scrollTo(id, anchor: .top)
+                        }
+                    }
                     .onChange(of: id) { newID in
                         if !pause {
-                            withAnimation {
+                            withAnimation(viewModel.isPlaying ? .default : nil) {
                                 scroll.scrollTo(newID, anchor: .top)
                             }
                         }

--- a/Course/Course/Presentation/Video/SubtitlesView.swift
+++ b/Course/Course/Presentation/Video/SubtitlesView.swift
@@ -33,6 +33,12 @@ public struct SubtitlesView: View {
     
     @State private var autoScrollPublisher = PassthroughSubject<Void, Never>()
     
+    private enum Constants {
+        static let autoScrollInterval: TimeInterval = 3.0
+        static let animationDuration: TimeInterval = 0.3
+        static let animationSkipInterval: TimeInterval = animationDuration + 0.05
+    }
+    
     public init(languages: [SubtitleUrl],
                 currentTime: Binding<Double>,
                 viewModel: VideoPlayerViewModel,
@@ -104,12 +110,18 @@ public struct SubtitlesView: View {
                     .onChange(of: id) { newID in
                         scrollTo(newID, in: scroll)
                     }
-                    .onReceive(autoScrollPublisher.debounce(for: .seconds(3), scheduler: DispatchQueue.main)) { _ in
-                        if pause {
-                            refreshID()
-                            pause = false
+                    .onReceive(
+                        autoScrollPublisher.debounce(
+                            for: .seconds(Constants.autoScrollInterval),
+                            scheduler: DispatchQueue.main
+                        ),
+                        perform: { _ in
+                            if pause {
+                                refreshID()
+                                pause = false
+                            }
                         }
-                    }
+                    )
                 }
             }.padding(.horizontal, 24)
                 .padding(.top, 16)
@@ -129,11 +141,11 @@ public struct SubtitlesView: View {
                 if viewModel.isPlaying {
                     isAnimating = true
                     
-                    withAnimation(.linear(duration: 0.3)) {
+                    withAnimation(.linear(duration: Constants.animationDuration)) {
                         scrollView.scrollTo(viewID, anchor: .top)
                     }
                     
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + Constants.animationSkipInterval) {
                         isAnimating = false
                         
                         if let nextBlock = syncBlock {

--- a/Course/Course/Presentation/Video/SubtitlesView.swift
+++ b/Course/Course/Presentation/Video/SubtitlesView.swift
@@ -28,6 +28,9 @@ public struct SubtitlesView: View {
     @State var pause: Bool = false
     @State var languages: [SubtitleUrl]
     
+    @State private var isAnimating = false
+    @State private var syncBlock: (() -> Void)?
+    
     @State private var autoScrollPublisher = PassthroughSubject<Void, Never>()
     
     public init(languages: [SubtitleUrl],
@@ -94,16 +97,12 @@ public struct SubtitlesView: View {
                         refreshID()
                     }
                     .onChange(of: viewModel.isPlaying) { isPlaying in
-                        if !pause && isPlaying {
-                            scroll.scrollTo(id, anchor: .top)
+                        if isPlaying {
+                            scrollTo(id, in: scroll)
                         }
                     }
                     .onChange(of: id) { newID in
-                        if !pause {
-                            withAnimation(viewModel.isPlaying ? .default : nil) {
-                                scroll.scrollTo(newID, anchor: .top)
-                            }
-                        }
+                        scrollTo(newID, in: scroll)
                     }
                     .onReceive(autoScrollPublisher.debounce(for: .seconds(3), scheduler: DispatchQueue.main)) { _ in
                         if pause {
@@ -121,6 +120,37 @@ public struct SubtitlesView: View {
     private func refreshID() {
         if let subtitle = viewModel.findSubtitle(at: Date(milliseconds: currentTime)) {
             id = subtitle.id
+        }
+    }
+    
+    private func scrollTo(_ viewID: Int, in scrollView: ScrollViewProxy) {
+        if !pause {
+            let scrollBlock = {
+                if viewModel.isPlaying {
+                    isAnimating = true
+                    
+                    withAnimation(.linear(duration: 0.3)) {
+                        scrollView.scrollTo(viewID, anchor: .top)
+                    }
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                        isAnimating = false
+                        
+                        if let nextBlock = syncBlock {
+                            syncBlock = nil
+                            nextBlock()
+                        }
+                    }
+                } else {
+                    scrollView.scrollTo(viewID, anchor: .top)
+                }
+            }
+            
+            if isAnimating {
+                syncBlock = scrollBlock
+            } else {
+                scrollBlock()
+            }
         }
     }
 }

--- a/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
+++ b/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
@@ -11,6 +11,7 @@ import _AVKit_SwiftUI
 import Combine
 
 public class VideoPlayerViewModel: ObservableObject {
+    @Published private(set) var isPlaying: Bool = false
     @Published var pause: Bool = false
     @Published var currentTime: Double = 0
     @Published var isLoading: Bool = true
@@ -101,6 +102,7 @@ public class VideoPlayerViewModel: ObservableObject {
         playerHolder.getRatePublisher()
             .sink {[weak self] rate in
                 guard self?.isLoading == false else { return }
+                self?.isPlaying = rate != 0
                 self?.trackVideoSpeedChange(rate: rate)
             }
             .store(in: &subscription)

--- a/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
+++ b/Course/Course/Presentation/Video/VideoPlayerViewModel.swift
@@ -101,8 +101,9 @@ public class VideoPlayerViewModel: ObservableObject {
         
         playerHolder.getRatePublisher()
             .sink {[weak self] rate in
-                guard self?.isLoading == false else { return }
                 self?.isPlaying = rate != 0
+                
+                guard self?.isLoading == false else { return }
                 self?.trackVideoSpeedChange(rate: rate)
             }
             .store(in: &subscription)


### PR DESCRIPTION
[LEARNER-10314](https://2u-internal.atlassian.net/browse/LEARNER-10314): iOS - Transcript gets out of sync when user seeks the video

Following scenarios have been implemented.
* The view will automatically scroll to current subtitle when the user seeks the video
* If the user manually scrolls the subtitles view, he will be automatically taken to the current subtitle after three seconds
* The view will also scroll to current subtitle if the user seeks the video in full screen mode

Here's a quick demo of the implementation.
<video src="https://github.com/user-attachments/assets/2928d16f-3e72-4bbd-a0a5-642dde3c9e30" />