### PR TITLE
chore: implement more options menu in notifications screen

### DIFF
--- a/Course/Course/Presentation/Video/SubtitlesView.swift
+++ b/Course/Course/Presentation/Video/SubtitlesView.swift
@@ -5,6 +5,7 @@
 //  Created by  Stepanok Ivan on 04.04.2023.
 //
 
+import Combine
 import SwiftUI
 import Core
 import Theme

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxView.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxView.swift
@@ -24,8 +24,12 @@ public struct NotificationsInboxView: View {
                 ZStack {
                     HStack {
                         Spacer()
-                        Button {
-                            // Open three dots menu
+                        Menu {
+                            ForEach(viewModel.menus, id: \.self) { menu in
+                                Button(menu.localizedValue) {
+                                    viewModel.menuSelected(menu)
+                                }
+                            }
                         } label: {
                             NotificationsAssets.threeDotsMenu.swiftUIImage
                                 .padding(.top, 3)

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -10,7 +10,7 @@ import Core
 import SwiftUI
 
 public class NotificationsInboxViewModel: ObservableObject {
-    
+    @Published private(set) var menus: [NotificationMenu] = NotificationMenu.allCases
     @Published private(set) var fetchInProgress = false
     @Published private(set) var refresh = false
     @Published var isShowProgress = true
@@ -43,10 +43,36 @@ public class NotificationsInboxViewModel: ObservableObject {
         self.router = router
     }
     
+    func menuSelected(_ menu: NotificationMenu) {
+        switch menu {
+        case .markAllAsRead:
+            Task {
+                await markAllNotificationsAsRead()
+            }
+        case .settings:
+            router.showPushSettings()
+        }
+    }
+    
     @MainActor
     func markNotificationAsRead(notificationId: String) async {
         do {
             _ = try await interactor.markNotificationAsRead(notificationId: notificationId)
+        } catch {
+            handleFetchError(error)
+        }
+    }
+    
+    @MainActor
+    func markAllNotificationsAsRead() async {
+        do {
+            _ = try await interactor.markAllNotificationsAsRead()
+            
+            flatNotifications = flatNotifications.map { item in
+                var readItem = item
+                readItem.lastRead = Date()
+                return readItem
+            }
         } catch {
             handleFetchError(error)
         }
@@ -157,6 +183,20 @@ public class NotificationsInboxViewModel: ObservableObject {
     private func updateFlatNotification(item: Notification) {
         if let index = flatNotifications.firstIndex(where: { $0.id == item.id }) {
             flatNotifications[index] = item
+        }
+    }
+}
+
+enum NotificationMenu: CaseIterable {
+    case markAllAsRead
+    case settings
+    
+    var localizedValue: String {
+        switch self {
+        case .markAllAsRead:
+            return NotificationsLocalization.Menu.markAllAsRead
+        case .settings:
+            return NotificationsLocalization.Menu.settings
         }
     }
 }

--- a/Notifications/Notifications/Presentation/NotificationsRouter.swift
+++ b/Notifications/Notifications/Presentation/NotificationsRouter.swift
@@ -9,12 +9,14 @@ import Foundation
 import Core
 
 public protocol NotificationsRouter: BaseRouter {
-    
+    func showPushSettings()
 }
 
 // Mark - For testing and SwiftUI preview
 #if DEBUG
 public class NotificationsRouterMock: BaseRouterMock, NotificationsRouter {
     public override init() {}
+    
+    public func showPushSettings() {}
 }
 #endif

--- a/Notifications/Notifications/SwiftGen/Strings.swift
+++ b/Notifications/Notifications/SwiftGen/Strings.swift
@@ -34,6 +34,12 @@ public enum NotificationsLocalization {
     /// This Week
     public static let thisWeek = NotificationsLocalization.tr("Localizable", "INBOX.THIS_WEEK", fallback: "This Week")
   }
+  public enum Menu {
+    /// Mark all as read
+    public static let markAllAsRead = NotificationsLocalization.tr("Localizable", "MENU.MARK_ALL_AS_READ", fallback: "Mark all as read")
+    /// Settings
+    public static let settings = NotificationsLocalization.tr("Localizable", "MENU.SETTINGS", fallback: "Settings")
+  }
   public enum Settings {
     /// Notifications for course discussions you post, comment, or follow.
     public static let preferenceDescription = NotificationsLocalization.tr("Localizable", "SETTINGS.PREFERENCE_DESCRIPTION", fallback: "Notifications for course discussions you post, comment, or follow.")

--- a/Notifications/Notifications/en.lproj/Localizable.strings
+++ b/Notifications/Notifications/en.lproj/Localizable.strings
@@ -19,3 +19,5 @@
 "INBOX.RECENT" = "Recent";
 "INBOX.THIS_WEEK" = "This Week";
 "INBOX.OLDER" = "Older";
+"MENU.MARK_ALL_AS_READ" = "Mark all as read";
+"MENU.SETTINGS" = "Settings";

--- a/Notifications/Notifications/uk.lproj/Localizable.strings
+++ b/Notifications/Notifications/uk.lproj/Localizable.strings
@@ -19,3 +19,5 @@
 "INBOX.RECENT" = "Recent";
 "INBOX.THIS_WEEK" = "This Week";
 "INBOX.OLDER" = "Older";
+"MENU.MARK_ALL_AS_READ" = "Mark all as read";
+"MENU.SETTINGS" = "Settings";

--- a/Notifications/NotificationsTests/NotificationsMock.generated.swift
+++ b/Notifications/NotificationsTests/NotificationsMock.generated.swift
@@ -3452,6 +3452,22 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
 		return __value
     }
 
+    open func getAllNotifications(page: Int) throws -> Notifications {
+        addInvocation(.m_getAllNotifications__page_page(Parameter<Int>.value(`page`)))
+		let perform = methodPerformValue(.m_getAllNotifications__page_page(Parameter<Int>.value(`page`))) as? (Int) -> Void
+		perform?(`page`)
+		var __value: Notifications
+		do {
+		    __value = try methodReturnValue(.m_getAllNotifications__page_page(Parameter<Int>.value(`page`))).casted()
+		} catch MockError.notStubed {
+			onFatalFailure("Stub return value not specified for getAllNotifications(page: Int). Use given")
+			Failure("Stub return value not specified for getAllNotifications(page: Int). Use given")
+		} catch {
+		    throw error
+		}
+		return __value
+    }
+
     open func getNotificationsPreferences() throws -> NotificationsPreferences {
         addInvocation(.m_getNotificationsPreferences)
 		let perform = methodPerformValue(.m_getNotificationsPreferences) as? () -> Void
@@ -3535,6 +3551,7 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
 
     fileprivate enum MethodType {
         case m_getNotificationsCount
+        case m_getAllNotifications__page_page(Parameter<Int>)
         case m_getNotificationsPreferences
         case m_updateNotificationsPreferences__value_value(Parameter<Bool>)
         case m_markNotificationsAsSeen
@@ -3544,6 +3561,11 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
             case (.m_getNotificationsCount, .m_getNotificationsCount): return .match
+
+            case (.m_getAllNotifications__page_page(let lhsPage), .m_getAllNotifications__page_page(let rhsPage)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPage, rhs: rhsPage, with: matcher), lhsPage, rhsPage, "page"))
+				return Matcher.ComparisonResult(results)
 
             case (.m_getNotificationsPreferences, .m_getNotificationsPreferences): return .match
 
@@ -3567,6 +3589,7 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
         func intValue() -> Int {
             switch self {
             case .m_getNotificationsCount: return 0
+            case let .m_getAllNotifications__page_page(p0): return p0.intValue
             case .m_getNotificationsPreferences: return 0
             case let .m_updateNotificationsPreferences__value_value(p0): return p0.intValue
             case .m_markNotificationsAsSeen: return 0
@@ -3577,6 +3600,7 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
         func assertionName() -> String {
             switch self {
             case .m_getNotificationsCount: return ".getNotificationsCount()"
+            case .m_getAllNotifications__page_page: return ".getAllNotifications(page:)"
             case .m_getNotificationsPreferences: return ".getNotificationsPreferences()"
             case .m_updateNotificationsPreferences__value_value: return ".updateNotificationsPreferences(value:)"
             case .m_markNotificationsAsSeen: return ".markNotificationsAsSeen()"
@@ -3597,6 +3621,9 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
 
         public static func getNotificationsCount(willReturn: NotificationsCount...) -> MethodStub {
             return Given(method: .m_getNotificationsCount, products: willReturn.map({ StubProduct.return($0 as Any) }))
+        }
+        public static func getAllNotifications(page: Parameter<Int>, willReturn: Notifications...) -> MethodStub {
+            return Given(method: .m_getAllNotifications__page_page(`page`), products: willReturn.map({ StubProduct.return($0 as Any) }))
         }
         public static func getNotificationsPreferences(willReturn: NotificationsPreferences...) -> MethodStub {
             return Given(method: .m_getNotificationsPreferences, products: willReturn.map({ StubProduct.return($0 as Any) }))
@@ -3620,6 +3647,16 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
             let willThrow: [Error] = []
 			let given: Given = { return Given(method: .m_getNotificationsCount, products: willThrow.map({ StubProduct.throw($0) })) }()
 			let stubber = given.stubThrows(for: (NotificationsCount).self)
+			willProduce(stubber)
+			return given
+        }
+        public static func getAllNotifications(page: Parameter<Int>, willThrow: Error...) -> MethodStub {
+            return Given(method: .m_getAllNotifications__page_page(`page`), products: willThrow.map({ StubProduct.throw($0) }))
+        }
+        public static func getAllNotifications(page: Parameter<Int>, willProduce: (StubberThrows<Notifications>) -> Void) -> MethodStub {
+            let willThrow: [Error] = []
+			let given: Given = { return Given(method: .m_getAllNotifications__page_page(`page`), products: willThrow.map({ StubProduct.throw($0) })) }()
+			let stubber = given.stubThrows(for: (Notifications).self)
 			willProduce(stubber)
 			return given
         }
@@ -3679,6 +3716,7 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
         fileprivate var method: MethodType
 
         public static func getNotificationsCount() -> Verify { return Verify(method: .m_getNotificationsCount)}
+        public static func getAllNotifications(page: Parameter<Int>) -> Verify { return Verify(method: .m_getAllNotifications__page_page(`page`))}
         public static func getNotificationsPreferences() -> Verify { return Verify(method: .m_getNotificationsPreferences)}
         public static func updateNotificationsPreferences(value: Parameter<Bool>) -> Verify { return Verify(method: .m_updateNotificationsPreferences__value_value(`value`))}
         public static func markNotificationsAsSeen() -> Verify { return Verify(method: .m_markNotificationsAsSeen)}
@@ -3692,6 +3730,9 @@ open class NotificationsInteractorProtocolMock: NotificationsInteractorProtocol,
 
         public static func getNotificationsCount(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_getNotificationsCount, performs: perform)
+        }
+        public static func getAllNotifications(page: Parameter<Int>, perform: @escaping (Int) -> Void) -> Perform {
+            return Perform(method: .m_getAllNotifications__page_page(`page`), performs: perform)
         }
         public static func getNotificationsPreferences(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_getNotificationsPreferences, performs: perform)


### PR DESCRIPTION
[LEARNER-10355](https://2u-internal.atlassian.net/browse/LEARNER-10355): Notifications Screen More Options

### Description
Following two menus will be shown when a user presses three dots button in notifications screen.
* **Mark all as read:** This option will hit an API to mark all available notifications as read.
* **Settings:** This option will navigate the user to push notifications settings screen.

### Preview
| Light Mode | Dark Mode |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-28 at 10 36 01](https://github.com/user-attachments/assets/9712a6eb-ae4c-4706-b79d-3d0d0929b38d) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-28 at 10 36 09](https://github.com/user-attachments/assets/65a836f7-b66e-483f-a362-6ffd6108014d) |