### PR TITLE
chore: System notification tray interaction

### DIFF
--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -132,7 +132,7 @@ public class NotificationsInboxViewModel: ObservableObject {
     }
     
     @MainActor
-    func markNotificationAsRead(notificationId: String) async {
+    public func markNotificationAsRead(notificationId: String) async {
         do {
             _ = try await interactor.markNotificationAsRead(notificationId: notificationId)
         } catch {

--- a/OpenEdX/DI/AppAssembly.swift
+++ b/OpenEdX/DI/AppAssembly.swift
@@ -202,7 +202,8 @@ class AppAssembly: Assembly {
                 discoveryInteractor: r.resolve(DiscoveryInteractorProtocol.self)!,
                 discussionInteractor: r.resolve(DiscussionInteractorProtocol.self)!,
                 courseInteractor: r.resolve(CourseInteractorProtocol.self)!,
-                profileInteractor: r.resolve(ProfileInteractorProtocol.self)!
+                profileInteractor: r.resolve(ProfileInteractorProtocol.self)!,
+                notificationsInteractor: r.resolve(NotificationsInteractorProtocol.self)!
             )
         }.inObjectScope(.container)
         

--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
@@ -40,6 +40,7 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
     private let discussionInteractor: DiscussionInteractorProtocol
     private let courseInteractor: CourseInteractorProtocol
     private let profileInteractor: ProfileInteractorProtocol
+    private let notificationsInteractor: NotificationsInteractorProtocol
     
     var userloggedIn: Bool {
         return !(storage.user?.username?.isEmpty ?? true)
@@ -52,7 +53,8 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
         discoveryInteractor: DiscoveryInteractorProtocol,
         discussionInteractor: DiscussionInteractorProtocol,
         courseInteractor: CourseInteractorProtocol,
-        profileInteractor: ProfileInteractorProtocol
+        profileInteractor: ProfileInteractorProtocol,
+        notificationsInteractor: NotificationsInteractorProtocol
     ) {
         self.config = config
         self.router = router
@@ -61,6 +63,7 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
         self.discussionInteractor = discussionInteractor
         self.courseInteractor = courseInteractor
         self.profileInteractor = profileInteractor
+        self.notificationsInteractor = notificationsInteractor
         
         services = servicesFor(config: config)
     }
@@ -285,9 +288,10 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                             return
                         }
                         
-                        if let notificationID = link.notificationID, !notificationID.isEmpty,
-                           let viewModel = Container.shared.resolve(NotificationsInboxViewModel.self) {
-                            _ = try? await viewModel.markNotificationAsRead(notificationId: notificationID)
+                        if let notificationID = link.notificationID, !notificationID.isEmpty {
+                            _ = try? await self.notificationsInteractor.markNotificationAsRead(
+                                notificationId: notificationID
+                            )
                         }
                         
                         await self.showCourseDiscussion(

--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
@@ -13,6 +13,7 @@ import Discussion
 import Course
 import Profile
 import Notifications
+import Swinject
 
 // swiftlint:disable function_body_length type_body_length
 //sourcery: AutoMockable
@@ -283,6 +284,12 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                         ) else {
                             return
                         }
+                        
+                        if let notificationID = link.notificationID, !notificationID.isEmpty,
+                           let viewModel = Container.shared.resolve(NotificationsInboxViewModel.self) {
+                            _ = try? await viewModel.markNotificationAsRead(notificationId: notificationID)
+                        }
+                        
                         await self.showCourseDiscussion(
                             link: link,
                             courseDetails: courseDetails,
@@ -333,6 +340,11 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
         courseDetails: CourseDetails,
         isBlackedOut: Bool
     ) async {
+        let responseId = link.parentID?.isEmpty == false &&
+        link.commentID?.isEmpty == false
+        ? link.parentID
+        : link.commentID
+
         switch link.type {
         case .discussionTopic:
             guard let topicID = link.topicID,
@@ -373,7 +385,8 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                 let userThread = try? await discussionInteractor.getThread(threadID: threadID) {
                 router.showThread(
                     userThread: userThread,
-                    isBlackedOut: isBlackedOut
+                    isBlackedOut: isBlackedOut,
+                    responseID: responseId
                 )
             }
         case .discussionComment, .forumResponse:
@@ -396,7 +409,8 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                 let userThread = try? await discussionInteractor.getThread(threadID: threadID) {
                 router.showThread(
                     userThread: userThread,
-                    isBlackedOut: isBlackedOut
+                    isBlackedOut: isBlackedOut,
+                    responseID: responseId
                 )
             }
 
@@ -433,7 +447,8 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                 let userThread = try? await discussionInteractor.getThread(threadID: threadID) {
                 router.showThread(
                     userThread: userThread,
-                    isBlackedOut: isBlackedOut
+                    isBlackedOut: isBlackedOut,
+                    responseID: responseId
                 )
             }
             

--- a/OpenEdX/Managers/DeepLinkManager/Link/DeepLink.swift
+++ b/OpenEdX/Managers/DeepLinkManager/Link/DeepLink.swift
@@ -40,6 +40,7 @@ private enum DeepLinkKeys: String, RawStringExtractable {
     case pathID = "path_id"
     case screenName = "screen_name"
     case notificationType = "notification_type"
+    case notificationID = "notification_id"
     case topicID = "topic_id"
     case threadID = "thread_id"
     case commentID = "comment_id"
@@ -50,6 +51,7 @@ private enum DeepLinkKeys: String, RawStringExtractable {
 public class DeepLink {
     let courseID: String?
     let screenName: String?
+    let notificationID: String?
     let notificationType: String?
     let pathID: String?
     let topicID: String?
@@ -62,6 +64,7 @@ public class DeepLink {
     init(dictionary: [AnyHashable: Any]) {
         courseID = dictionary[DeepLinkKeys.courseID.rawValue] as? String
         screenName = dictionary[DeepLinkKeys.screenName.rawValue] as? String
+        notificationID = dictionary[DeepLinkKeys.notificationID.rawValue] as? String
         notificationType = dictionary[DeepLinkKeys.notificationType.rawValue] as? String
         pathID = dictionary[DeepLinkKeys.pathID.rawValue] as? String
         topicID = dictionary[DeepLinkKeys.topicID.rawValue] as? String


### PR DESCRIPTION
[LEARNER-10291](https://2u-internal.atlassian.net/browse/LEARNER-10291): System notification tray interaction considerations

### Acceptance Criteria:
- Notifications are marked as read as soon as the app opens after the user interacts with a system notification.
- The app navigates the user to the relevant discussion topic/response when the required IDs are available in the notification payload.
- When IDs are missing, the app opens without issues, directing the user to the Learn Tab.

### Demo:

In Background | In Foreground | 
--- | --- | 
<video src="https://github.com/user-attachments/assets/13316c13-fd03-4b54-8fd3-0fb4eff2693e" /> | <video src="https://github.com/user-attachments/assets/279da137-10c4-4aa8-ba25-4732d5d03ac0" /> | 
