### PR TITLE
chore: Update Discussion Responses Order to Show Latest First

### DIFF
--- a/Discussion/Discussion/Data/Network/DiscussionEndpoint.swift
+++ b/Discussion/Discussion/Data/Network/DiscussionEndpoint.swift
@@ -200,6 +200,7 @@ enum DiscussionEndpoint: EndPointType {
         case let .getDiscussionComments(threadID, page):
             let parameters: [String: Encodable] = [
                 "thread_id": threadID,
+                "reverse_order": "true",
                 "requested_fields": "profile_image",
                 "page": page
             ]
@@ -208,12 +209,14 @@ enum DiscussionEndpoint: EndPointType {
             let parameters: [String: Encodable] = [
                 "thread_id": threadID,
                 "endorsed": false,
+                "reverse_order": "true",
                 "requested_fields": "profile_image",
                 "page": page
             ]
             return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         case let .getCommentResponses(_, page):
             let parameters: [String: Encodable] = [
+                "reverse_order": "true",
                 "requested_fields": "profile_image",
                 "page": page
             ]

--- a/Discussion/Discussion/Presentation/Comments/Base/BaseResponsesViewModel.swift
+++ b/Discussion/Discussion/Presentation/Comments/Base/BaseResponsesViewModel.swift
@@ -171,7 +171,7 @@ public class BaseResponsesViewModel {
     
     func addNewPost(_ post: Post) {
         let newPostWithAvatar = post
-        postComments?.comments.append(newPostWithAvatar)
+        postComments?.comments.insert(newPostWithAvatar, at: 0)
         itemsCount += 1
     }
     

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
@@ -192,15 +192,11 @@ public struct ResponsesView: View {
                     .onReceive(viewModel.addPostSubject, perform: { newComment in
                         guard let newComment else { return }
                         viewModel.sendThreadPostsCountState()
-                        if viewModel.nextPage - 1 == viewModel.totalPages {
-                            viewModel.addNewPost(newComment)
-                            withAnimation {
-                                guard let count = viewModel.postComments?.comments.count else { return }
-                                scroll.scrollTo(count - 2, anchor: .top)
+                        viewModel.addNewPost(newComment)
+                        withAnimation {
+                            if !(viewModel.postComments?.comments.isEmpty ?? true) {
+                                scroll.scrollTo(0, anchor: .bottom)
                             }
-                        } else {
-                            viewModel.alertMessage = DiscussionLocalization.Response.Alert.commentAdded
-                            viewModel.showAlert = true
                         }
                     })
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
@@ -194,7 +194,7 @@ public struct ResponsesView: View {
                         viewModel.sendThreadPostsCountState()
                         viewModel.addNewPost(newComment)
                         withAnimation {
-                            if !(viewModel.postComments?.comments.isEmpty ?? true) {
+                            if viewModel.postComments?.comments.isEmpty == false {
                                 scroll.scrollTo(0, anchor: .bottom)
                             }
                         }

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
@@ -190,7 +190,7 @@ public struct ThreadView: View {
                             viewModel.sendPostRepliesCountState()
                             viewModel.addNewPost(newComment)
                             withAnimation {
-                                if !(viewModel.postComments?.comments.isEmpty ?? true) {
+                                if viewModel.postComments?.comments.isEmpty == false {
                                     scroll.scrollTo(0, anchor: .bottom)
                                 }
                             }

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
@@ -188,15 +188,11 @@ public struct ThreadView: View {
                         .onReceive(viewModel.addPostSubject, perform: { newComment in
                             guard let newComment else { return }
                             viewModel.sendPostRepliesCountState()
-                            if viewModel.nextPage - 1 == viewModel.totalPages {
-                                viewModel.addNewPost(newComment)
-                                withAnimation {
-                                    guard let count = viewModel.postComments?.comments.count else { return }
-                                    scroll.scrollTo(count - 2, anchor: .top)
+                            viewModel.addNewPost(newComment)
+                            withAnimation {
+                                if !(viewModel.postComments?.comments.isEmpty ?? true) {
+                                    scroll.scrollTo(0, anchor: .bottom)
                                 }
-                            } else {
-                                viewModel.alertMessage = DiscussionLocalization.Thread.Alert.commentAdded
-                                viewModel.showAlert = true
                             }
                         })
                         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Discussion/DiscussionTests/Presentation/Comment/Base/BaseResponsesViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/Comment/Base/BaseResponsesViewModelTests.swift
@@ -440,7 +440,7 @@ final class BaseResponsesViewModelTests: XCTestCase {
         
         viewModel.addNewPost(newPost)
         
-        XCTAssertTrue(viewModel.postComments!.comments.last!.authorName == "new")
+        XCTAssertTrue(viewModel.postComments!.comments.first!.authorName == "new")
     }
     
 }


### PR DESCRIPTION
[LEARNER-10449](https://2u-internal.atlassian.net/browse/LEARNER-10449): Update Discussion Responses Order to Show Latest First

### Acceptance Criteria:
1. **Reverse Order of Responses in API**
   1. Responses on the post responses screen should be displayed in reverse chronological order (latest first).
   2. Update the API request to include reverse_order=true when fetching responses.
   3. The order should match the web application’s behavior.
2. **Update "Add a Response" and "Add a Comment" Behavior**
   1. Newly added responses and comments should appear at the top of the list instead of the bottom.
   2. Ensure UI updates instantly to reflect the correct order after adding a response or comment.
