### PR TITLE
chore: upgarade upload-artifact version to v4

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: bundle exec fastlane unit_tests
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-output


### PR DESCRIPTION
### Description

This PR upgrades the version of `actions/upload-artifact` from v2 to v4. 