### PR TITLE
chore: Remove foreground notification experience

### DIFF
--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
@@ -107,14 +107,8 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
             return
         }
         
-        let isAppActive = UIApplication.shared.applicationState == .active
-        
         Task {
-            if isAppActive {
-                await showNotificationAlert(link)
-            } else {
-                await navigateToScreen(with: link.type, link: link)
-            }
+            await navigateToScreen(with: link.type, link: link)
         }
     }
     
@@ -181,6 +175,8 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
         with type: DeepLinkType,
         link: DeepLink
     ) async {
+        router.dismissPresentedViewController()
+        
         if isDiscovery(type: type) {
             showDiscoveryScreen(with: type, link: link)
             return

--- a/OpenEdX/Managers/Payload.swift
+++ b/OpenEdX/Managers/Payload.swift
@@ -29,6 +29,6 @@ struct Payload {
     }
 
     subscript(key: PayloadKey) -> String? {
-        return dictionary[key] as? String
+        return dictionary[key.rawValue] as? String
     }
 }

--- a/OpenEdX/Managers/PushNotificationsManager/PushNotificationsManager.swift
+++ b/OpenEdX/Managers/PushNotificationsManager/PushNotificationsManager.swift
@@ -169,8 +169,6 @@ extension PushNotificationsManager: UNUserNotificationCenterDelegate {
             let userInfo = notification.request.content.userInfo
             let payload = Payload(dictionary: userInfo)
             trackPushReceived(payload: payload) // For foreground state.
-            didReceiveRemoteNotification(userInfo: userInfo)
-            return []
         }
         
         return [[.list, .banner, .sound]]


### PR DESCRIPTION
[LEARNER-10458](https://2u-internal.atlassian.net/browse/LEARNER-10458): Remove foreground notification experience

### Context:
We need to remove the alert shown when a learner gets a push notification. Alerts are mainly there to stop the user from doing what they are doing and get them to do an action. In our case, getting a notification should not block the user from what they are doing.

### Acceptance Criteria
- No alert should be shown when a learner receives a push notification from the edx app.
- If a learner is watching a video in fullscreen mode, the video should not be exited when a push notification is received by the learner. 

Normal Flow | Full Screen Video Playing Mode | 
--- | --- | 
<video src="https://github.com/user-attachments/assets/f74d5fa4-6379-40d0-a657-00fe234dd3e0" /> | <video src="https://github.com/user-attachments/assets/729e46cb-ccdc-4d91-94c1-5957dfb516d0" /> | 
