### PR TITLE
fix: Unread Marker Reappears on Notifications After Pagination

### DIFF
--- a/Core/Core/Network/Pagination/PaginationManager.swift
+++ b/Core/Core/Network/Pagination/PaginationManager.swift
@@ -174,7 +174,8 @@ public final class PaginationManager<Item, PaginationKey> {
     ///
     /// - Parameters:
     ///   - updatedItem: The updated item that should replace the existing one.
-    ///   - id: A closure that extracts a unique identifier from an `Item`. This is used to find the matching item in the list.
+    ///   - id: A closure that extracts a unique identifier from an `Item`.
+    ///         This is used to find the matching item in the list.
     ///
     /// - Note: If the item with the same identifier exists in the current list, it will be replaced with `updatedItem`,
     ///         and the updated list will be published to `itemsPublisher`.
@@ -183,7 +184,8 @@ public final class PaginationManager<Item, PaginationKey> {
     ///   ```swift
     ///   paginationManager.updateItem(updatedPost) { $0.id }
     ///   ```
-    ///   In this example, `{ $0.id }` extracts the `id` of each item (assuming `Item` is a struct with an `id` property),
+    ///   In this example, `{ $0.id }` extracts the `id`
+    ///   of each item (assuming `Item` is a struct with an `id` property),
     ///   allowing the function to locate and update the correct item.
     ///
     /// - Important: This method must be called on the main thread since it updates UI-related state.

--- a/Core/Core/Network/Pagination/PaginationManager.swift
+++ b/Core/Core/Network/Pagination/PaginationManager.swift
@@ -170,6 +170,39 @@ public final class PaginationManager<Item, PaginationKey> {
         }
     }
     
+    /// Updates an existing item in the list if it matches the given identifier.
+    ///
+    /// - Parameters:
+    ///   - updatedItem: The updated item that should replace the existing one.
+    ///   - id: A closure that extracts a unique identifier from an `Item`. This is used to find the matching item in the list.
+    ///
+    /// - Note: If the item with the same identifier exists in the current list, it will be replaced with `updatedItem`,
+    ///         and the updated list will be published to `itemsPublisher`.
+    ///
+    /// - Example:
+    ///   ```swift
+    ///   paginationManager.updateItem(updatedPost) { $0.id }
+    ///   ```
+    ///   In this example, `{ $0.id }` extracts the `id` of each item (assuming `Item` is a struct with an `id` property),
+    ///   allowing the function to locate and update the correct item.
+    ///
+    /// - Important: This method must be called on the main thread since it updates UI-related state.
+    ///
+    /// - SeeAlso: `itemsPublisher`
+    @MainActor
+    public func updateItem(_ updatedItem: Item, id: (Item) -> AnyHashable) {
+        // Get the current list of items; if no items exist, exit the function.
+        guard var currentItems = itemsSubject.value else { return }
+        
+        // Find the index of the item that matches the updatedItem based on the identifier.
+        if let index = currentItems.firstIndex(where: { id($0) == id(updatedItem) }) {
+            // Replace the old item with the updated item.
+            currentItems[index] = updatedItem
+            // Publish the updated list.
+            itemsSubject.send(currentItems)
+        }
+    }
+
     @MainActor
     private func clearTask(_ paginationTask: PaginationTask<Item>) {
         if paginationTask == refreshTask {

--- a/Core/Core/Network/Pagination/PaginationManager.swift
+++ b/Core/Core/Network/Pagination/PaginationManager.swift
@@ -128,28 +128,26 @@ public final class PaginationManager<Item, PaginationKey> {
         return loadMoreTask
     }
 
-    /// Updates an existing item based on a given predicate and transformation.
+    /// Provides thread-safe access to the current items.
     ///
-    /// - Parameters:
-    ///   - predicate: A closure that returns `true` if an item should be updated.
-    ///   - transform: A closure that modifies the matching item.
+    /// - Parameter body: A closure that receives an inout array of items. If `body` has a return
+    ///                   value, that value is also used as the return value for the
+    ///                   `withItems(_:)` method. The array is valid only for the duration of the
+    ///                   method’s execution.
+    /// - Returns: The value returned from `body`, or `nil` if items are not available.
+    /// - Note: Always notifies subscribers after modification.
+    /// - Important: The closure executes synchronously on the main actor.
     @MainActor
-    public func updateItem(
-        where predicate: (Item) -> Bool,
-        transform: (inout Item) -> Void
-    ) {
-        guard var currentItems = itemsSubject.value else { return }
-
-        var updateCount = 0
-
-        for index in currentItems.indices where predicate(currentItems[index]) {
-            transform(&currentItems[index])
-            updateCount += 1
+    public func withItems<Result>(
+        _ body: (inout [Item]) throws -> Result
+    ) rethrows -> Result? {
+        guard var currentItems = itemsSubject.value else {
+            return nil
         }
 
-        if updateCount > 0 {
-            itemsSubject.send(currentItems)
-        }
+        let result = try body(&currentItems)
+        itemsSubject.send(currentItems)
+        return result
     }
 
     // MARK: - Private Methods
@@ -205,18 +203,53 @@ public final class PaginationManager<Item, PaginationKey> {
     }
 }
 
+extension PaginationManager {
+    /// Updates the first item matching the predicate using the provided transform.
+    ///
+    /// **Example:**
+    /// ```swift
+    /// // Update first active item's status.
+    /// paginationManager.updateFirstItem(
+    ///     matching: { $0.isActive },
+    ///     transform: { item in
+    ///         item.isActive = false
+    ///         item.lastUpdated = Date()
+    ///     }
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - predicate: A closure that determines whether an item should be updated.
+    ///   - transform: A closure that modifies the matching item.
+    @MainActor
+    public func updateFirstItem(
+        matching predicate: (Item) -> Bool,
+        transform: (inout Item) -> Void
+    ) {
+        withItems { items in
+            if let index = items.firstIndex(where: predicate) {
+                transform(&items[index])
+            }
+        }
+    }
+}
+
 /// Conditional extension for `Identifiable` items.
 extension PaginationManager where Item: Identifiable {
-    /// Updates an existing item in the list by replacing it with a new version.
+    /// Replaces the first item whose ID matches the provided item's ID.
     ///
-    /// - Parameter updatedItem: The new version of the item with matching identifier.
+    /// - Parameter item: The new version of the item with matching identifier..
+    /// - Returns: `true` if replacement occurred, `false` otherwise.
     @MainActor
-    public func updateItem(_ updatedItem: Item) {
-        updateItem(
-            where: { $0.id == updatedItem.id },
-            transform: { existingItem in
-                existingItem = updatedItem
+    @discardableResult
+    public func replaceFirstItemWithMatchingID(_ item: Item) -> Bool {
+        return withItems { items in
+            guard let index = items.firstIndex(where: { $0.id == item.id }) else {
+                return false
             }
-        )
+
+            items[index] = item
+            return true
+        } ?? false
     }
 }

--- a/Core/Core/Network/Pagination/PaginationManager.swift
+++ b/Core/Core/Network/Pagination/PaginationManager.swift
@@ -127,7 +127,31 @@ public final class PaginationManager<Item, PaginationKey> {
         
         return loadMoreTask
     }
-    
+
+    /// Updates an existing item based on a given predicate and transformation.
+    ///
+    /// - Parameters:
+    ///   - predicate: A closure that returns `true` if an item should be updated.
+    ///   - transform: A closure that modifies the matching item.
+    @MainActor
+    public func updateItem(
+        where predicate: (Item) -> Bool,
+        transform: (inout Item) -> Void
+    ) {
+        guard var currentItems = itemsSubject.value else { return }
+
+        var updateCount = 0
+
+        for index in currentItems.indices where predicate(currentItems[index]) {
+            transform(&currentItems[index])
+            updateCount += 1
+        }
+
+        if updateCount > 0 {
+            itemsSubject.send(currentItems)
+        }
+    }
+
     // MARK: - Private Methods
     
     @MainActor
@@ -169,41 +193,6 @@ public final class PaginationManager<Item, PaginationKey> {
             }
         }
     }
-    
-    /// Updates an existing item in the list if it matches the given identifier.
-    ///
-    /// - Parameters:
-    ///   - updatedItem: The updated item that should replace the existing one.
-    ///   - id: A closure that extracts a unique identifier from an `Item`.
-    ///         This is used to find the matching item in the list.
-    ///
-    /// - Note: If the item with the same identifier exists in the current list, it will be replaced with `updatedItem`,
-    ///         and the updated list will be published to `itemsPublisher`.
-    ///
-    /// - Example:
-    ///   ```swift
-    ///   paginationManager.updateItem(updatedPost) { $0.id }
-    ///   ```
-    ///   In this example, `{ $0.id }` extracts the `id`
-    ///   of each item (assuming `Item` is a struct with an `id` property),
-    ///   allowing the function to locate and update the correct item.
-    ///
-    /// - Important: This method must be called on the main thread since it updates UI-related state.
-    ///
-    /// - SeeAlso: `itemsPublisher`
-    @MainActor
-    public func updateItem(_ updatedItem: Item, id: (Item) -> AnyHashable) {
-        // Get the current list of items; if no items exist, exit the function.
-        guard var currentItems = itemsSubject.value else { return }
-        
-        // Find the index of the item that matches the updatedItem based on the identifier.
-        if let index = currentItems.firstIndex(where: { id($0) == id(updatedItem) }) {
-            // Replace the old item with the updated item.
-            currentItems[index] = updatedItem
-            // Publish the updated list.
-            itemsSubject.send(currentItems)
-        }
-    }
 
     @MainActor
     private func clearTask(_ paginationTask: PaginationTask<Item>) {
@@ -213,5 +202,21 @@ public final class PaginationManager<Item, PaginationKey> {
         if paginationTask == loadMoreTask {
             loadMoreTask = nil
         }
+    }
+}
+
+/// Conditional extension for `Identifiable` items.
+extension PaginationManager where Item: Identifiable {
+    /// Updates an existing item in the list by replacing it with a new version.
+    ///
+    /// - Parameter updatedItem: The new version of the item with matching identifier.
+    @MainActor
+    public func updateItem(_ updatedItem: Item) {
+        updateItem(
+            where: { $0.id == updatedItem.id },
+            transform: { existingItem in
+                existingItem = updatedItem
+            }
+        )
     }
 }

--- a/Notifications/Notifications/Domain/Model/Notifications.swift
+++ b/Notifications/Notifications/Domain/Model/Notifications.swift
@@ -32,7 +32,7 @@ public struct Notifications: Hashable {
     }
 }
 
-public struct SingleNotification: Hashable {
+public struct SingleNotification: Identifiable, Hashable {
     public let id: Int
     public let appName: String?
     public let notificationType: String?

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -243,22 +243,8 @@ public class NotificationsInboxViewModel: ObservableObject {
     
     // Update a specific item in the array
     @MainActor
-    func updateNotification(groupKey: NotificationGroup, item: SingleNotification) {
-        updateGroupedNotification(groupKey: groupKey, item: item)
-        updateFlatNotification(item: item)
-        paginationManager.updateItem(item) { $0.id }
-    }
-
-    private func updateGroupedNotification(groupKey: NotificationGroup, item: SingleNotification) {
-        if let index = groupedNotifications[groupKey]?.firstIndex(where: { $0.id == item.id }) {
-            groupedNotifications[groupKey]?[index] = item
-        }
-    }
-
-    private func updateFlatNotification(item: SingleNotification) {
-        if let index = flatNotifications.firstIndex(where: { $0.id == item.id }) {
-            flatNotifications[index] = item
-        }
+    func updateNotification(_ updatedNotification: SingleNotification) {
+        paginationManager.updateItem(updatedNotification)
     }
 }
 

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -244,7 +244,7 @@ public class NotificationsInboxViewModel: ObservableObject {
     // Update a specific item in the array
     @MainActor
     func updateNotification(_ updatedNotification: SingleNotification) {
-        paginationManager.updateItem(updatedNotification)
+        paginationManager.replaceFirstItemWithMatchingID(updatedNotification)
     }
 }
 

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -242,9 +242,11 @@ public class NotificationsInboxViewModel: ObservableObject {
     }
     
     // Update a specific item in the array
+    @MainActor
     func updateNotification(groupKey: NotificationGroup, item: SingleNotification) {
         updateGroupedNotification(groupKey: groupKey, item: item)
         updateFlatNotification(item: item)
+        paginationManager.updateItem(item) { $0.id }
     }
 
     private func updateGroupedNotification(groupKey: NotificationGroup, item: SingleNotification) {

--- a/Notifications/Notifications/Presentation/NotificationsInbox/SingleNotificationView.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/SingleNotificationView.swift
@@ -29,12 +29,11 @@ struct SingleNotificationView: View {
                 Task {
                     await viewModel.showDiscussions(notification)
                     await viewModel.markNotificationAsRead(notificationId: String(notification.id))
+
                     var updatedNotification = notification
                     updatedNotification.lastRead = Date()
-                    viewModel.updateNotification(
-                        groupKey: groupKey,
-                        item: updatedNotification
-                    )
+                    
+                    viewModel.updateNotification(updatedNotification)
                 }
             }
         ) {


### PR DESCRIPTION
[LEARNER-10474](https://2u-internal.atlassian.net/browse/LEARNER-10474): Unread Marker Reappears on Notifications After Pagination

### Acceptance Criteria:

1. When a user taps on a notification, its read state should persist across pagination and screen refreshes.
2. The unread marker should not reappear for notifications that have already been read.
3. Scrolling through pages and returning to the first page should not reset the read state of notifications.
4. The read state should be consistently maintained even after navigating away and returning to the notifications inbox.
5. Ensure that the backend and local data remain in sync to prevent discrepancies in notification states.