### PR TITLE
fix: Pagination not working after pulling down to refresh for some devices

### DIFF
--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxView.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxView.swift
@@ -183,6 +183,7 @@ public struct NotificationsInboxView: View {
                             .onAppear {
                                 viewModel.fetchMoreNotificationsIfNeeded(for: item)
                             }
+                            .id(item.id)
                         }
                     }
                 }

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxView.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxView.swift
@@ -148,6 +148,7 @@ public struct NotificationsInboxView: View {
     @ViewBuilder
     private func list(geometry: GeometryProxy) -> some View {
         RefreshableScrollViewCompat(action: {
+            viewModel.regenerateUniqueID()
             await viewModel.refreshNotifications()
         }) {
             LazyVStack(spacing: 16) {
@@ -195,6 +196,7 @@ public struct NotificationsInboxView: View {
                 }
             }
             .frameLimit(width: geometry.size.width)
+            .id(viewModel.uniqueID)
         }
     }
 }

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxView.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxView.swift
@@ -148,7 +148,7 @@ public struct NotificationsInboxView: View {
     @ViewBuilder
     private func list(geometry: GeometryProxy) -> some View {
         RefreshableScrollViewCompat(action: {
-            viewModel.regenerateUniqueID()
+            viewModel.regenerateLazyVStackUniqueID()
             await viewModel.refreshNotifications()
         }) {
             LazyVStack(spacing: 16) {
@@ -197,7 +197,7 @@ public struct NotificationsInboxView: View {
                 }
             }
             .frameLimit(width: geometry.size.width)
-            .id(viewModel.uniqueID)
+            .id(viewModel.lazyVStackUniqueID)
         }
     }
 }

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -30,6 +30,7 @@ public class NotificationsInboxViewModel: ObservableObject {
     private let calendar = Calendar.current
     private var interactor: NotificationsInteractorProtocol
     private var cancellables = Set<AnyCancellable>()
+    private(set) var uniqueID: String = UUID().uuidString
     private var flatNotifications: [SingleNotification] = [] {
         didSet { groupItems() }
     }
@@ -110,6 +111,10 @@ public class NotificationsInboxViewModel: ObservableObject {
             trackPushNotificationsSettingClicked()
             router.showPushSettings()
         }
+    }
+    
+    func regenerateUniqueID() {
+        uniqueID = UUID().uuidString
     }
     
     @MainActor

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -30,7 +30,7 @@ public class NotificationsInboxViewModel: ObservableObject {
     private let calendar = Calendar.current
     private var interactor: NotificationsInteractorProtocol
     private var cancellables = Set<AnyCancellable>()
-    private(set) var uniqueID: String = UUID().uuidString
+    private(set) var lazyVStackUniqueID: String = UUID().uuidString
     private var flatNotifications: [SingleNotification] = [] {
         didSet { groupItems() }
     }
@@ -113,8 +113,8 @@ public class NotificationsInboxViewModel: ObservableObject {
         }
     }
     
-    func regenerateUniqueID() {
-        uniqueID = UUID().uuidString
+    func regenerateLazyVStackUniqueID() {
+        lazyVStackUniqueID = UUID().uuidString
     }
     
     @MainActor


### PR DESCRIPTION
[LEARNER-10483](https://2u-internal.atlassian.net/browse/LEARNER-10483): Pagination not working after pulling down to refresh for some devices

### Description:
On the Notifications Inbox Screen, pagination stops working after performing a pull-down refresh. We have a pagination size of 12 notifications per page for iPhone devices. On larger devices (e.g., iPhone 16 Pro Max), where 12 notifications fit on the screen without scrolling, the second page API call is triggered automatically on the first load. After pulling down to refresh, scrolling down does not trigger the next page load, and the loading indicator does not appear and no more data is loaded.

### Acceptance Criteria:
- After a pull-down refresh, scrolling down should trigger the next page API call.
- Pagination should work consistently after performing a refresh.

### Reason:
We check whether the next page should load inside the `.onAppear` of `SingleNotificationView`. But when we pull down to refresh, the first page preloaded for better user experience, and `.onAppear` doesn’t get called again for those views. As a result, our `fetchMoreNotificationsIfNeeded` method doesn’t run, so the next page isn't requested.

### Solution:
We update the `.id()` of the `LazyVStack` when pull-to-refresh happens, so that `.onAppear` gets triggered again.