### PR TITLE
feat: integrate firebase performance library

### DIFF
--- a/OpenEdX.xcodeproj/project.pbxproj
+++ b/OpenEdX.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		14D912D72C2551F60077CCCE /* FullStoryAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D912D62C2551F60077CCCE /* FullStoryAnalyticsService.swift */; };
 		1924EDE8164C7AB17AD4946B /* Pods_App_OpenEdX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC49621A0942E5EE74BDC895 /* Pods_App_OpenEdX.framework */; };
 		94AE32322D8838E400FA048D /* Payload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AE32312D8838DE00FA048D /* Payload.swift */; };
+		94F4AC6C2DAD398200D50B61 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 94F4AC6B2DAD398200D50B61 /* FirebasePerformance */; };
 		A500668B2B613ED10024680B /* PushNotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500668A2B613ED10024680B /* PushNotificationsManager.swift */; };
 		A500668D2B6143000024680B /* FCMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500668C2B6143000024680B /* FCMProvider.swift */; };
 		A50066912B61467B0024680B /* BrazeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50066902B61467B0024680B /* BrazeProvider.swift */; };
@@ -214,6 +215,7 @@
 				0219C67728F4347600D64452 /* Course.framework in Frameworks */,
 				0780ABE32BFBA2E40093A4A6 /* FirebaseAnalytics in Frameworks */,
 				027DB33028D8A063002B6862 /* Dashboard.framework in Frameworks */,
+				94F4AC6C2DAD398200D50B61 /* FirebasePerformance in Frameworks */,
 				A5BD3E302B83B0F7006A8983 /* SegmentFirebase in Frameworks */,
 				149B52D92C5FE5AB00C7BF5D /* FirebaseCrashlytics in Frameworks */,
 				A51CDBED2B6D2BEE009B6D4E /* SegmentBraze in Frameworks */,
@@ -487,6 +489,7 @@
 				0780ABE42BFBA2E40093A4A6 /* FirebaseMessaging */,
 				14D912D22C25483F0077CCCE /* FullStory */,
 				149B52D82C5FE5AB00C7BF5D /* FirebaseCrashlytics */,
+				94F4AC6B2DAD398200D50B61 /* FirebasePerformance */,
 			);
 			productName = OpenEdX;
 			productReference = 07D5DA3128D075AA00752FD9 /* OpenEdX.app */;
@@ -1390,6 +1393,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 14D912D12C25483F0077CCCE /* XCRemoteSwiftPackageReference "fullstory-swift-package-ios" */;
 			productName = FullStory;
+		};
+		94F4AC6B2DAD398200D50B61 /* FirebasePerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0780ABE12BFBA2E40093A4A6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebasePerformance;
 		};
 		A51CDBEC2B6D2BEE009B6D4E /* SegmentBraze */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
[LEARNER-10424](https://2u-internal.atlassian.net/browse/LEARNER-10424): Add Firebase API Performance plugin

### Technical Details
`FirebasePerformance` library has been added in the main `OpenEdX` project. No additional configuration is needed as per the official [documentation](https://firebase.google.com/docs/perf-mon/get-started-ios). The following steps were already covered in the project:
* Add the `-ObjC` flag to the _Other Linker Flags_ section of your target's build settings.
* Configure a [FirebaseApp](https://firebase.google.com/docs/reference/swift/firebasecore/api/reference/Classes/FirebaseApp) shared instance in your app delegate's launch method: `FirebaseApp.configure()`

### Preview
| Metric | Sample |
| - | - |
| **App start time** | <img width="1098" alt="Screenshot 2025-04-17 at 5 53 03 PM" src="https://github.com/user-attachments/assets/2d5bff4d-b3c4-485e-807a-50f852d950fb" /> |
| **Network requests** | <img width="1099" alt="Screenshot 2025-04-17 at 5 55 35 PM" src="https://github.com/user-attachments/assets/0383f578-2dbd-434a-ac57-d8b6f4a30763" /> |