### PR TITLE
fix: fixed NSError crash in tests

### DIFF
--- a/Authorization/AuthorizationTests/Presentation/Login/ResetPasswordViewModelTests.swift
+++ b/Authorization/AuthorizationTests/Presentation/Login/ResetPasswordViewModelTests.swift
@@ -140,7 +140,7 @@ final class ResetPasswordViewModelTests: XCTestCase {
                                                analytics: analytics,
                                                validator: validator)
 
-        Given(interactor, .resetPassword(email: .any, willThrow: NSError()))
+        Given(interactor, .resetPassword(email: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
 
         var isRecoveryPassword = true
         let binding = Binding(get: {

--- a/Authorization/AuthorizationTests/Presentation/Login/SignInViewModelTests.swift
+++ b/Authorization/AuthorizationTests/Presentation/Login/SignInViewModelTests.swift
@@ -236,7 +236,7 @@ final class SignInViewModelTests: XCTestCase {
             sourceScreen: .default
         )
         
-        Given(interactor, .login(username: .any, password: .any, willThrow: NSError()))
+        Given(interactor, .login(username: .any, password: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.login(username: "edxUser@edx.com", password: "password123")
         

--- a/Authorization/AuthorizationTests/Presentation/Register/SignUpViewModelTests.swift
+++ b/Authorization/AuthorizationTests/Presentation/Register/SignUpViewModelTests.swift
@@ -99,7 +99,7 @@ final class SignUpViewModelTests: XCTestCase {
             sourceScreen: .default
         )
         
-        Given(interactor, .getRegistrationFields(willThrow: NSError()))
+        Given(interactor, .getRegistrationFields(willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.getRegistrationFields()
         
@@ -228,7 +228,7 @@ final class SignUpViewModelTests: XCTestCase {
         )
         
         Given(interactor, .validateRegistrationFields(fields: .any, willReturn: [:]))
-        Given(interactor, .registerUser(fields: .any, isSocial: .any, willThrow: NSError()))
+        Given(interactor, .registerUser(fields: .any, isSocial: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
 
         await viewModel.registerUser()
         

--- a/Course/CourseTests/Presentation/Container/CourseContainerViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Container/CourseContainerViewModelTests.swift
@@ -316,7 +316,7 @@ final class CourseContainerViewModelTests: XCTestCase {
         )
         
         Given(interactor, .getCourseBlocks(courseID: "123",
-                                           willThrow: NSError()))
+                                           willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.getCourseBlocks(courseID: "123")
         

--- a/Course/CourseTests/Presentation/Unit/CourseDateViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Unit/CourseDateViewModelTests.swift
@@ -85,7 +85,7 @@ final class CourseDateViewModelTests: XCTestCase {
         let connectivity = ConnectivityProtocolMock()
         let config = ConfigMock()
         
-        Given(interactor, .getCourseDates(courseID: .any, willThrow: NSError()))
+        Given(interactor, .getCourseDates(courseID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         let viewModel = CourseDatesViewModel(
             interactor: interactor,

--- a/Course/CourseTests/Presentation/Unit/CourseUnitViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Unit/CourseUnitViewModelTests.swift
@@ -190,7 +190,7 @@ final class CourseUnitViewModelTests: XCTestCase {
         
         Given(interactor, .blockCompletionRequest(courseID: .any,
                                                   blockID: .any,
-                                                  willThrow: NSError()))
+                                                  willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.blockCompletionRequest(blockID: "1")
         

--- a/Course/CourseTests/Presentation/Unit/HandoutsViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Unit/HandoutsViewModelTests.swift
@@ -73,8 +73,8 @@ final class HandoutsViewModelTests: XCTestCase {
         let router = CourseRouterMock()
         let connectivity = ConnectivityProtocolMock()
         
-        Given(interactor, .getHandouts(courseID: .any, willThrow: NSError()))
-        Given(interactor, .getUpdates(courseID: .any, willThrow: NSError()))
+        Given(interactor, .getHandouts(courseID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        Given(interactor, .getUpdates(courseID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         let viewModel = HandoutsViewModel(
             interactor: interactor,
@@ -158,7 +158,7 @@ final class HandoutsViewModelTests: XCTestCase {
             analytics: CourseAnalyticsMock())
         
         
-        Given(interactor, .getUpdates(courseID: .any, willThrow: NSError()))
+        Given(interactor, .getUpdates(courseID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.getUpdates(courseID: "")
         

--- a/Course/CourseTests/Presentation/Unit/VideoPlayerViewModelTests.swift
+++ b/Course/CourseTests/Presentation/Unit/VideoPlayerViewModelTests.swift
@@ -146,7 +146,7 @@ final class VideoPlayerViewModelTests: XCTestCase {
             analytics: CourseAnalyticsMock()
         )
         
-        Given(interactor, .blockCompletionRequest(courseID: .any, blockID: .any, willThrow: NSError()))
+        Given(interactor, .blockCompletionRequest(courseID: .any, blockID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await playerHolder.sendCompletion()
         

--- a/Dashboard/DashboardTests/Presentation/DashboardViewModelTests.swift
+++ b/Dashboard/DashboardTests/Presentation/DashboardViewModelTests.swift
@@ -191,7 +191,7 @@ final class ListDashboardViewModelTests: XCTestCase {
         )
         
         Given(connectivity, .isInternetAvaliable(getter: true))
-        Given(interactor, .getEnrollments(page: .any, willThrow: NSError()) )
+        Given(interactor, .getEnrollments(page: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)) )
         
         await viewModel.getMyCourses(page: 1)
         

--- a/Discovery/DiscoveryTests/Presentation/CourseDetailsViewModelTests.swift
+++ b/Discovery/DiscoveryTests/Presentation/CourseDetailsViewModelTests.swift
@@ -188,7 +188,7 @@ final class CourseDetailsViewModelTests: XCTestCase {
                                                storage: CoreStorageMock())
         
         Given(interactor, .getCourseDetails(courseID: "123",
-                                            willThrow: NSError()))
+                                            willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.getCourseDetail(courseID: "123")
         

--- a/Discussion/DiscussionTests/Presentation/Comment/Base/BaseResponsesViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/Comment/Base/BaseResponsesViewModelTests.swift
@@ -206,7 +206,7 @@ final class BaseResponsesViewModelTests: XCTestCase {
 
         var result = false
         
-        Given(interactor, .voteThread(voted: .any, threadID: .any, willThrow: NSError()))
+        Given(interactor, .voteThread(voted: .any, threadID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         result = await viewModel.vote(id: "1", isThread: true, voted: true, index: nil, courseID: "courseID")
         
@@ -314,7 +314,7 @@ final class BaseResponsesViewModelTests: XCTestCase {
 
         var result = false
 
-        Given(interactor, .flagThread(abuseFlagged: .any, threadID: .any, willThrow: NSError()))
+        Given(interactor, .flagThread(abuseFlagged: .any, threadID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         result = await viewModel.flag(id: "1", isThread: true, abuseFlagged: true, index: nil, courseID: "courseID")
         
@@ -394,7 +394,7 @@ final class BaseResponsesViewModelTests: XCTestCase {
 
         var result = false
 
-        Given(interactor, .followThread(following: .any, threadID: .any, willThrow: NSError()))
+        Given(interactor, .followThread(following: .any, threadID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         result = await viewModel.followThread(following: true, threadID: "1")
 

--- a/Discussion/DiscussionTests/Presentation/Comment/ThreadViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/Comment/ThreadViewModelTests.swift
@@ -326,8 +326,8 @@ final class ThreadViewModelTests: XCTestCase {
                                         responseID: "1",
                                         analytics: DiscussionAnalyticsMock())
                         
-        Given(interactor, .readBody(threadID: .any, willThrow: NSError()))
-        Given(interactor, .getQuestionComments(threadID: .any, page: .any, willThrow: NSError()))
+        Given(interactor, .readBody(threadID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        Given(interactor, .getQuestionComments(threadID: .any, page: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
                 
         result = await viewModel.getThreadData(thread: threads.threads[0], page: 1)
         
@@ -430,7 +430,7 @@ final class ThreadViewModelTests: XCTestCase {
                                         responseID: "1",
                                         analytics: DiscussionAnalyticsMock())
                         
-        Given(interactor, .addCommentTo(threadID: .any, rawBody: .any, parentID: .any, willThrow: NSError()) )
+        Given(interactor, .addCommentTo(threadID: .any, rawBody: .any, parentID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)) )
                 
         await viewModel.postComment(courseID: "CourseID", threadID: "1", rawBody: "1", parentID: nil)
         

--- a/Discussion/DiscussionTests/Presentation/CreateNewThread/CreateNewThreadViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/CreateNewThread/CreateNewThreadViewModelTests.swift
@@ -93,7 +93,7 @@ final class CreateNewThreadViewModelTests: XCTestCase {
             storage: CoreStorageMock()
         )
         
-        Given(interactor, .createNewThread(newThread: .any, willThrow: NSError()))
+        Given(interactor, .createNewThread(newThread: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         result = await viewModel.createNewThread(newThread: newThread)
         

--- a/Discussion/DiscussionTests/Presentation/DiscussionTopics/DiscussionSearchTopicsViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/DiscussionTopics/DiscussionSearchTopicsViewModelTests.swift
@@ -104,7 +104,7 @@ final class DiscussionSearchTopicsViewModelTests: XCTestCase {
                                                         router: router,
                                                         debounce: .test)
 
-        Given(interactor, .searchThreads(courseID: .any, searchText: .any, pageNumber: .any, willThrow: NSError()))
+        Given(interactor, .searchThreads(courseID: .any, searchText: .any, pageNumber: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
 
         viewModel.searchText = "Test"
         

--- a/Discussion/DiscussionTests/Presentation/DiscussionTopics/DiscussionTopicsViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/DiscussionTopics/DiscussionTopicsViewModelTests.swift
@@ -102,7 +102,7 @@ final class DiscussionTopicsViewModelTests: XCTestCase {
                                                   analytics: analytics,
                                                   config: config)
         
-        Given(interactor, .getTopics(courseID: .any, willThrow: NSError()))
+        Given(interactor, .getTopics(courseID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         Given(interactor, .getCourseDiscussionInfo(courseID: .any, willReturn: discussionInfo))
 
         await viewModel.getTopics(courseID: "1")

--- a/Discussion/DiscussionTests/Presentation/Posts/PostViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/Posts/PostViewModelTests.swift
@@ -181,8 +181,8 @@ final class PostViewModelTests: XCTestCase {
         let viewModel = PostsViewModel(interactor: interactor, router: router, config: config, analytics: DiscussionAnalyticsMock())
         viewModel.isBlackedOut = false
 
-        Given(interactor, .getThreadsList(courseID: .any, type: .any, sort: .any, filter: .any, page: .any, willThrow: NSError()))
-        Given(interactor, .getCourseDiscussionInfo(courseID: .any, willThrow: NSError()))
+        Given(interactor, .getThreadsList(courseID: .any, type: .any, sort: .any, filter: .any, page: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        Given(interactor, .getCourseDiscussionInfo(courseID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
 
         viewModel.courseID = "1"
         viewModel.type = .allPosts

--- a/Discussion/DiscussionTests/Presentation/Responses/ResponsesViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/Responses/ResponsesViewModelTests.swift
@@ -177,7 +177,7 @@ final class ResponsesViewModelTests: XCTestCase {
                                            threadStateSubject: .init(.postAdded(id: "1")),
                                            analytics: DiscussionAnalyticsMock())
         
-        Given(interactor, .getCommentResponses(commentID: .any, page: .any, willThrow: NSError()))
+        Given(interactor, .getCommentResponses(commentID: .any, page: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         result = await viewModel.getResponsesData(commentID: "1", parentComment: post, page: 1)
         
@@ -256,7 +256,7 @@ final class ResponsesViewModelTests: XCTestCase {
                                            threadStateSubject: .init(.postAdded(id: "1")),
                                            analytics: DiscussionAnalyticsMock())
         
-        Given(interactor, .addCommentTo(threadID: .any, rawBody: .any, parentID: .any, willThrow: NSError()))
+        Given(interactor, .addCommentTo(threadID: .any, rawBody: .any, parentID: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
 
         await viewModel.postComment(threadID: "1", rawBody: "1", parentID: nil)
         

--- a/Profile/ProfileTests/Presentation/DeleteAccount/DeleteAccountViewModelTests.swift
+++ b/Profile/ProfileTests/Presentation/DeleteAccount/DeleteAccountViewModelTests.swift
@@ -93,7 +93,7 @@ final class DeleteAccountViewModelTests: XCTestCase {
             analytics: ProfileAnalyticsMock()
         )
         
-        Given(interactor, .deleteAccount(password: .any, willThrow: NSError()))
+        Given(interactor, .deleteAccount(password: .any, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         try await viewModel.deleteAccount(password: "123")
         

--- a/Profile/ProfileTests/Presentation/EditProfile/EditProfileViewModelTests.swift
+++ b/Profile/ProfileTests/Presentation/EditProfile/EditProfileViewModelTests.swift
@@ -643,7 +643,7 @@ final class EditProfileViewModelTests: XCTestCase {
         
         Given(interactor, .uploadProfilePicture(pictureData: .any, willProduce: {_ in}))
         Given(interactor, .updateUserProfile(parameters: .any,
-                                             willThrow: NSError()))
+                                             willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.saveProfileUpdates()
         

--- a/Profile/ProfileTests/Presentation/Profile/ProfileViewModelTests.swift
+++ b/Profile/ProfileTests/Presentation/Profile/ProfileViewModelTests.swift
@@ -76,7 +76,7 @@ final class ProfileViewModelTests: XCTestCase {
             username: "Steve"
         )
         
-        Given(interactor, .getUserProfile(username: .value("Steve"), willThrow: NSError()))
+        Given(interactor, .getUserProfile(username: .value("Steve"), willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.getUserProfile()
         
@@ -221,7 +221,7 @@ final class ProfileViewModelTests: XCTestCase {
         )
         
         Given(connectivity, .isInternetAvaliable(getter: true))
-        Given(interactor, .getMyProfile(willThrow: NSError()))
+        Given(interactor, .getMyProfile(willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
         
         await viewModel.getMyProfile()
         


### PR DESCRIPTION
[LEARNER-10512](https://2u-internal.atlassian.net/browse/LEARNER-10512): Exceptions in SwiftyMocky pod while running test cases on Xcode 16.3

This PR repeats fixes for Xcode 16.3 for Tests like did [this commit in openEdx repo](https://github.com/openedx/openedx-app-ios/pull/577/commits/cd41e3b89a3699c0369ee10340a8e7c95ef8f375). NSError should be init with parameters now.