### PR TITLE
fix: bottom padding issue on discovery screens

### DIFF
--- a/Core/Core/View/Base/Webview/Models/ReadabilityInjection.swift
+++ b/Core/Core/View/Base/Webview/Models/ReadabilityInjection.swift
@@ -46,6 +46,7 @@ public struct ReadabilityInjection: WebViewScriptInjectionProtocol, CSSInjection
             body {
                 padding-left: \(padding)px !important;
                 padding-right: \(padding)px !important;
+                padding-bottom: 200px !important;
             }
         """
     }

--- a/Core/Core/View/Base/Webview/WebView.swift
+++ b/Core/Core/View/Base/Webview/WebView.swift
@@ -273,7 +273,7 @@ public struct WebView: UIViewRepresentable {
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = Theme.Colors.background.uiColor()
         webView.scrollView.alwaysBounceVertical = false
-        webView.scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 200, right: 0)
+        webView.scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         // To add ability to change font size with webkitTextSizeAdjust need to set mode to mobile
         webView.configuration.defaultWebpagePreferences.preferredContentMode = .mobile
         webView.applyInjections(viewModel.injections, toHandler: context.coordinator)


### PR DESCRIPTION
[LEARNER-10351](https://2u-internal.atlassian.net/browse/LEARNER-10351): Extra space at the bottom of all the discovery screens

### Steps to Reproduce
1. Launch the **edX** app.
2. Tap on **Discover** tab.
3. Search for any course.
4. Scroll the screen up.
5. Notice the extra space at the bottom of the screen.

### Technical Details
- Set the bottom content inset of the `WebView` to `0`.
- Added `200px` bottom padding inside the `ReadabilityInjection` to preserve existing layout behavior where it's in use.

### Impact
Discovery screens were not using `ReadabilityInjection`, so setting the bottom inset to `0` removes the unnecessary space at the bottom of those screens.

Screens that do use `ReadabilityInjection` will continue to behave as before due to the added padding, ensuring layout consistency across the app.

### Screenshots
| Before | After |
| - | - |
|  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-22 at 11 35 01](https://github.com/user-attachments/assets/0185dec2-7017-48c6-b6d3-0a8bd9e48dd0) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-22 at 11 46 07](https://github.com/user-attachments/assets/fce61512-5e14-47bb-82e4-51554c231ab7) |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-22 at 11 37 54](https://github.com/user-attachments/assets/d8edd2a9-9f62-44d5-80c5-36e3fafcd26e) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-22 at 11 47 13](https://github.com/user-attachments/assets/07717d33-c77d-444b-ad09-bb67ece86229) |
