### PR TITLE
feat: show track selection screen on course enrollment

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,7 +60,7 @@ file_length:
   
 function_parameter_count:
   warning: 10
-  error: 12
+  error: 13
 
 type_name:
   min_length: 3 # only warning

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,7 +60,7 @@ file_length:
   
 function_parameter_count:
   warning: 10
-  error: 13
+  error: 12
 
 type_name:
   min_length: 3 # only warning

--- a/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
+++ b/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
@@ -1080,6 +1080,13 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -1168,6 +1175,7 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -1284,6 +1292,17 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -1348,6 +1367,7 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -1380,6 +1400,7 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -1426,6 +1447,8 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -1504,6 +1527,10 @@ open class AuthorizationRouterMock: AuthorizationRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {
@@ -1766,6 +1793,13 @@ open class BaseRouterMock: BaseRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -1853,6 +1887,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -1964,6 +1999,17 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -2027,6 +2073,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -2058,6 +2105,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -2103,6 +2151,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -2178,6 +2228,10 @@ open class BaseRouterMock: BaseRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {
@@ -2623,6 +2677,18 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
     }
 
+    open func trackSelectionViewed(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
+    open func trackContinueWithFreeTrackClicked(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
     open func trackEvent(_ event: AnalyticsEvent) {
         addInvocation(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`)))
 		let perform = methodPerformValue(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`))) as? (AnalyticsEvent) -> Void
@@ -2664,6 +2730,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         case m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeMode>)
         case m_trackRestorePurchaseClicked
         case m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
         case m_trackEvent__event(Parameter<AnalyticsEvent>)
         case m_trackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_trackScreenEvent__event(Parameter<AnalyticsEvent>)
@@ -2804,6 +2872,22 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_trackEvent__event(let lhsEvent), .m_trackEvent__event(let rhsEvent)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
@@ -2846,6 +2930,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case let .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case .m_trackRestorePurchaseClicked: return 0
             case let .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case let .m_trackEvent__event(p0): return p0.intValue
             case let .m_trackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_trackScreenEvent__event(p0): return p0.intValue
@@ -2869,6 +2955,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType: return ".trackCourseUnfulfilledPurchaseInitiated(courseID:pacing:screen:flowType:)"
             case .m_trackRestorePurchaseClicked: return ".trackRestorePurchaseClicked()"
             case .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackValuePropViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackSelectionViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackContinueWithFreeTrackClicked(courseID:pacing:lmsPrice:screen:)"
             case .m_trackEvent__event: return ".trackEvent(_:)"
             case .m_trackEvent__eventbiValue_biValue: return ".trackEvent(_:biValue:)"
             case .m_trackScreenEvent__event: return ".trackScreenEvent(_:)"
@@ -2906,6 +2994,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         public static func trackCourseUnfulfilledPurchaseInitiated(courseID: Parameter<String>, pacing: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, flowType: Parameter<UpgradeMode>) -> Verify { return Verify(method: .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(`courseID`, `pacing`, `screen`, `flowType`))}
         public static func trackRestorePurchaseClicked() -> Verify { return Verify(method: .m_trackRestorePurchaseClicked)}
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackEvent__event(`event`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_trackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func trackScreenEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackScreenEvent__event(`event`))}
@@ -2960,6 +3050,12 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         }
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
             return Perform(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
         }
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, perform: @escaping (AnalyticsEvent) -> Void) -> Perform {
             return Perform(method: .m_trackEvent__event(`event`), performs: perform)

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -185,6 +185,10 @@
 		942A98552D4BD91700DD8BBC /* PaginationTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942A98542D4BD91700DD8BBC /* PaginationTask.swift */; };
 		942A98572D4BD92B00DD8BBC /* PaginationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942A98562D4BD92B00DD8BBC /* PaginationResult.swift */; };
 		942A98592D4CAF5200DD8BBC /* ScreenStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942A98582D4CAF5200DD8BBC /* ScreenStateView.swift */; };
+		942C4D522DC505F1002BA81C /* TrackSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942C4D512DC505F1002BA81C /* TrackSelectionView.swift */; };
+		942C4D542DC508B7002BA81C /* TrackCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942C4D532DC508B7002BA81C /* TrackCardView.swift */; };
+		949094972DC8E2D800A341D4 /* TrackSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949094962DC8E2D100A341D4 /* TrackSelectionViewModel.swift */; };
+		949094992DC8E44C00A341D4 /* TrackCardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949094982DC8E44700A341D4 /* TrackCardInfo.swift */; };
 		9499F1262D41375B00558D59 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9499F1252D41375B00558D59 /* AppEnvironment.swift */; };
 		94AE32362D8B329D00FA048D /* NotificationBellButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AE32352D8B329D00FA048D /* NotificationBellButton.swift */; };
 		94D1FC482DA6AF44000A904F /* EDXFeatureManagement in Frameworks */ = {isa = PBXBuildFile; productRef = 94D1FC472DA6AF44000A904F /* EDXFeatureManagement */; };
@@ -428,6 +432,10 @@
 		942A98542D4BD91700DD8BBC /* PaginationTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTask.swift; sourceTree = "<group>"; };
 		942A98562D4BD92B00DD8BBC /* PaginationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationResult.swift; sourceTree = "<group>"; };
 		942A98582D4CAF5200DD8BBC /* ScreenStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenStateView.swift; sourceTree = "<group>"; };
+		942C4D512DC505F1002BA81C /* TrackSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionView.swift; sourceTree = "<group>"; };
+		942C4D532DC508B7002BA81C /* TrackCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackCardView.swift; sourceTree = "<group>"; };
+		949094962DC8E2D100A341D4 /* TrackSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionViewModel.swift; sourceTree = "<group>"; };
+		949094982DC8E44700A341D4 /* TrackCardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackCardInfo.swift; sourceTree = "<group>"; };
 		9499F1252D41375B00558D59 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		94AE32352D8B329D00FA048D /* NotificationBellButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBellButton.swift; sourceTree = "<group>"; };
 		94D1FC4C2DA7F39F000A904F /* OptimizelyConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyConfig.swift; sourceTree = "<group>"; };
@@ -637,6 +645,7 @@
 			children = (
 				062C69AE2C198337002BD311 /* PaymentSnackbarModifierViewModel.swift */,
 				062C69AF2C198337002BD311 /* UpgradeInfoViewModel.swift */,
+				949094962DC8E2D100A341D4 /* TrackSelectionViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -709,6 +718,7 @@
 				06EA8A4C2BFDFF70005DFB90 /* StoreKitUpgradeResponse.swift */,
 				06EA8A4E2BFDFF8F005DFB90 /* StoreProductInfo.swift */,
 				06EA8A502BFDFFB0005DFB90 /* UpgradeError.swift */,
+				949094982DC8E44700A341D4 /* TrackCardInfo.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -938,6 +948,8 @@
 				062C69A62C198323002BD311 /* UpgradeInfoView.swift */,
 				149936CD2BEB4F8900B4C89F /* CourseUpgradeUnlockView.swift */,
 				14F8E66A2C0F4D1200E4EF69 /* RestoreInProgressView.swift */,
+				942C4D512DC505F1002BA81C /* TrackSelectionView.swift */,
+				942C4D532DC508B7002BA81C /* TrackCardView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1394,6 +1406,7 @@
 				070019AE28F701B200D5FC78 /* Certificate.swift in Sources */,
 				BA4AFB442B6A5AF100A21367 /* CheckBoxView.swift in Sources */,
 				076F297F2A1F80C800967E7D /* Pagination.swift in Sources */,
+				942C4D542DC508B7002BA81C /* TrackCardView.swift in Sources */,
 				14769D3C2B9822EE00AB36D4 /* CoreAnalytics.swift in Sources */,
 				02AFCC1A2AEFDC18000360F0 /* ThirdPartyMailer.swift in Sources */,
 				0770DE5F28D0B22C006D8A5D /* Strings.swift in Sources */,
@@ -1435,6 +1448,7 @@
 				941613E22D8D4ACE00178F62 /* OnPressButtonStyle.swift in Sources */,
 				062C69AC2C198323002BD311 /* UpgradeInfoView.swift in Sources */,
 				064987952B4D69FF0071642A /* SurveyCssInjection.swift in Sources */,
+				949094992DC8E44C00A341D4 /* TrackCardInfo.swift in Sources */,
 				02E224DB2BB76B3E00EF1ADB /* DynamicOffsetView.swift in Sources */,
 				0259104A29C4A5B6004B5A55 /* UserSettings.swift in Sources */,
 				021D925028DC89D100ACC565 /* UserProfile.swift in Sources */,
@@ -1444,6 +1458,7 @@
 				06EA8A532BFE006F005DFB90 /* StoreKitHandlerProtocol.swift in Sources */,
 				0284DBFE28D48C5300830893 /* CourseItem.swift in Sources */,
 				0248C92329C075EF00DC8402 /* CourseBlockModel.swift in Sources */,
+				949094972DC8E2D800A341D4 /* TrackSelectionViewModel.swift in Sources */,
 				E0D5861A2B2FF74C009B4BA7 /* DiscoveryConfig.swift in Sources */,
 				94AE32362D8B329D00FA048D /* NotificationBellButton.swift in Sources */,
 				14A8325D2BD7629B00E5654D /* CourseUpgradeEndpoint.swift in Sources */,
@@ -1516,6 +1531,7 @@
 				020D72F42BB76DFE00773319 /* VisualEffectView.swift in Sources */,
 				0727878928D31734002E9142 /* User.swift in Sources */,
 				A53A32352B233DEC005FE38A /* ThemeConfig.swift in Sources */,
+				942C4D522DC505F1002BA81C /* TrackSelectionView.swift in Sources */,
 				02280F5B294B4E6F0032823A /* Connectivity.swift in Sources */,
 				149936CE2BEB4F8900B4C89F /* CourseUpgradeUnlockView.swift in Sources */,
 				06EA8A4A2BFDFF25005DFB90 /* CourseUpgradeInteractorProtocol.swift in Sources */,

--- a/Core/Core/Analytics/CoreAnalytics.swift
+++ b/Core/Core/Analytics/CoreAnalytics.swift
@@ -103,6 +103,20 @@ public protocol CoreAnalytics {
         lmsPrice: Double,
         screen: CourseUpgradeScreen
     )
+
+    func trackSelectionViewed(
+        courseID: String,
+        pacing: String,
+        lmsPrice: Double,
+        screen: CourseUpgradeScreen
+    )
+
+    func trackContinueWithFreeTrackClicked(
+        courseID: String,
+        pacing: String,
+        lmsPrice: Double,
+        screen: CourseUpgradeScreen
+    )
 }
 
 public extension CoreAnalytics {
@@ -214,6 +228,20 @@ public class CoreAnalyticsMock: CoreAnalytics {
     public func trackRestorePurchaseClicked() {}
     
     public func trackValuePropViewed(
+        courseID: String,
+        pacing: String,
+        lmsPrice: Double,
+        screen: CourseUpgradeScreen
+    ) {}
+
+    public func trackSelectionViewed(
+        courseID: String,
+        pacing: String,
+        lmsPrice: Double,
+        screen: CourseUpgradeScreen
+    ) {}
+
+    public func trackContinueWithFreeTrackClicked(
         courseID: String,
         pacing: String,
         lmsPrice: Double,
@@ -331,6 +359,8 @@ public enum AnalyticsEvent: String {
     case courseUpgradeUnfulfilledPurchaseInitiated = "Payments:Unfulfilled Purchase Initiated"
     case courseUpgradeRestorePurchaseClicked = "Payments:Restore Purchases Clicked"
     case courseUpgradeValuePropViewed = "Payments:Value Prop Viewed"
+    case trackSelectionViewed = "Payments:Track Selection Viewed"
+    case continueWithFreeTrackClicked = "Payments:Continue With Free Track Clicked"
     case logistration = "Logistration"
     case logistrationSignIn = "Logistration:Sign In"
     case logistrationRegister = "Logistration:Register"
@@ -477,6 +507,8 @@ public enum EventBIValue: String {
     case courseUpgradeUnfulfilledPurchaseInitiated = "edx.bi.app.payments.unfulfilled_purchase.initiated"
     case courseUpgradeRestorePurchaseClicked = "edx.bi.app.payments.restore_purchases.clicked"
     case courseUpgradeValuePropViewed = "edx.bi.app.payments.value_prop.viewed"
+    case trackSelectionViewed = "edx.bi.app.payments.track_selection.viewed"
+    case continueWithFreeTrackClicked = "edx.bi.app.payments.continue_with_free_track.clicked"
     case logistration = "edx.bi.app.logistration"
     case logistrationSignIn = "edx.bi.app.logistration.signin"
     case logistrationRegister = "edx.bi.app.logistration.register"

--- a/Core/Core/Configuration/BaseRouter.swift
+++ b/Core/Core/Configuration/BaseRouter.swift
@@ -60,7 +60,18 @@ public protocol BaseRouter {
     func presentView(transitionStyle: UIModalTransitionStyle, animated: Bool, content: () -> any View)
     
     func presentNativeAlert(title: String?, message: String?, actions: [UIAlertAction])
-    
+
+    @MainActor
+    func showTrackSelection(
+        courseID: String,
+        productName: String,
+        screen: CourseUpgradeScreen,
+        sku: String,
+        pacing: String,
+        lmsPrice: Double,
+        accessExpires: Date
+    )
+
     @MainActor
     func showUpgradeInfo(
         productName: String,
@@ -166,7 +177,18 @@ open class BaseRouterMock: BaseRouter {
     public func presentView(transitionStyle: UIModalTransitionStyle, animated: Bool, content: () -> any View) {}
     
     public func presentNativeAlert(title: String?, message: String?, actions: [UIAlertAction]) {}
-    
+
+    @MainActor
+    public func showTrackSelection(
+        courseID: String,
+        productName: String,
+        screen: CourseUpgradeScreen,
+        sku: String,
+        pacing: String,
+        lmsPrice: Double,
+        accessExpires: Date
+    ) {}
+
     @MainActor
     public func showUpgradeInfo(
         productName: String,

--- a/Core/Core/CourseUpgrade/CourseUpgradeHandler.swift
+++ b/Core/Core/CourseUpgrade/CourseUpgradeHandler.swift
@@ -17,7 +17,17 @@ public enum CourseUpgradeScreen: String {
 public enum UpgradeMode: String {
     case silent
     case userInitiated = "user_initiated"
+    case trackSelection = "track_selection"
     case restore
+
+    var isUserInitiated: Bool {
+        switch self {
+        case .userInitiated, .trackSelection:
+            return true
+        case .silent, .restore:
+            return false
+        }
+    }
 }
 
 public enum UpgradeState {
@@ -63,7 +73,7 @@ public class CourseUpgradeHandler: CourseUpgradeHandlerProtocol {
         case .basket, .checkout, .payment:
             return .payment
         case .verify:
-            return .fulfillment(showLoader: upgradeMode == .userInitiated)
+            return .fulfillment(showLoader: upgradeMode.isUserInitiated)
         case .complete:
             return .success(courseID, componentID)
         case .error(let error):
@@ -149,7 +159,7 @@ public class CourseUpgradeHandler: CourseUpgradeHandlerProtocol {
         state = .checkout
         do {
             _ = try await interactor.checkoutBasket(basketID: basketID)
-            if upgradeMode != .userInitiated {
+            if !upgradeMode.isUserInitiated {
                 await reverifyPayment()
             } else {
                 let response = await makePayment(sku: sku)

--- a/Core/Core/CourseUpgrade/CourseUpgradeHelper.swift
+++ b/Core/Core/CourseUpgrade/CourseUpgradeHelper.swift
@@ -126,7 +126,7 @@ public class CourseUpgradeHelper: CourseUpgradeHelperProtocol {
             }
         case .success(let courseID, let blockID):
             helperModel = CourseUpgradeHelperModel(courseID: courseID, blockID: blockID, screen: screen)
-            if upgradeHadler.upgradeMode == .userInitiated {
+            if upgradeHadler.upgradeMode.isUserInitiated {
                 removeLoader(success: true, shouldRemoveView: true)
                 postSuccessNotification()
             } else {
@@ -207,7 +207,7 @@ public class CourseUpgradeHelper: CourseUpgradeHelperProtocol {
                 removeInProgressIAP()
             }
             
-            if upgradeError != .verifyReceiptError(upgradeError), upgradeMode == .userInitiated {
+            if upgradeError != .verifyReceiptError(upgradeError), upgradeMode.isUserInitiated {
                 removeInProgressIAP()
             }
         default:

--- a/Core/Core/CourseUpgrade/Models/TrackCardInfo.swift
+++ b/Core/Core/CourseUpgrade/Models/TrackCardInfo.swift
@@ -1,0 +1,18 @@
+//
+//  TrackCardInfo.swift
+//  Core
+//
+//  Created by Muhammad Tayyab Akram on 5/5/25.
+//
+
+struct TrackCardInfo {
+    var heading: String
+    var subheading: String
+    var description: String
+
+    var paragraphs: [String] {
+        return description
+            .split(separator: "\n")
+            .map { String($0) }
+    }
+}

--- a/Core/Core/CourseUpgrade/View/TrackCardView.swift
+++ b/Core/Core/CourseUpgrade/View/TrackCardView.swift
@@ -1,0 +1,104 @@
+//
+//  TrackCardView.swift
+//  Core
+//
+//  Created by Muhammad Tayyab Akram on 5/2/25.
+//
+
+import SwiftUI
+import Theme
+
+struct TrackCardView: View {
+    var heading: String
+    var subheading: String
+    var paragraphs: [String]
+    var isSelected: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                .resizable()
+                .foregroundColor(Theme.Colors.textPrimary)
+                .frame(width: 24, height: 24)
+                .padding(2)
+
+            VStack(alignment: .leading, spacing: .zero) {
+                // Card Header
+                VStack(alignment: .leading, spacing: .zero) {
+                    Text(heading)
+                        .font(Theme.Fonts.titleMedium)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if !subheading.isEmpty {
+                        Text(subheading)
+                            .font(Theme.Fonts.bodyLarge)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .foregroundColor(Theme.Colors.textPrimary)
+
+                // Card Section
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(paragraphs, id: \.self) { paragraph in
+                        Text(paragraph)
+                            .foregroundColor(Theme.Colors.textPrimary)
+                            .font(Theme.Fonts.bodyMedium)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.top, 16)
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.leading, 16)
+        .padding(.trailing, 24)
+        .padding(.vertical, 20)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(
+                    isSelected ? Theme.Colors.accentColor : Theme.Colors.datesSectionStroke,
+                    lineWidth: 2
+                )
+        )
+        .background(Theme.Colors.datesSectionBackground)
+        .clipShape(
+            RoundedRectangle(cornerRadius: 6)
+        )
+        .if(isSelected) { view in
+            view
+                .shadow(color: Theme.Colors.shadowColor, radius: 4, y: 1)
+                .shadow(color: Theme.Colors.shadowColor, radius: 2, y: 1)
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack {
+        TrackCardView(
+            heading: "Earn a certificate for $99",
+            subheading: "",
+            paragraphs: [
+                "Get access to all graded course activities and course materials, even after the course ends.",
+                "Earn a verified certificate of completion."
+            ],
+            isSelected: true
+        )
+
+        TrackCardView(
+            heading: "Access this course",
+            subheading: "Access expires January 1st",
+            paragraphs: [
+                "Limited access to non-graded activities and course material."
+            ],
+            isSelected: false
+        )
+    }
+    .fixedSize(horizontal: false, vertical: true)
+    .padding(24)
+}
+#endif

--- a/Core/Core/CourseUpgrade/View/TrackSelectionView.swift
+++ b/Core/Core/CourseUpgrade/View/TrackSelectionView.swift
@@ -1,0 +1,149 @@
+//
+//  TrackSelectionView.swift
+//  Core
+//
+//  Created by Muhammad Tayyab Akram on 5/2/25.
+//
+
+import SwiftUI
+import Theme
+
+public struct TrackSelectionView: View {
+    @Environment(\.isHorizontal) private var isHorizontal
+    @ObservedObject private var viewModel: TrackSelectionViewModel
+
+    public init(viewModel: TrackSelectionViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        NavigationView {
+            VStack {
+                scrollView
+                    .padding(.horizontal, 24)
+                    .padding(.top, 24)
+
+                Spacer(minLength: 16)
+
+                ZStack {
+                    let buttonTitle = viewModel.continueTitle ?? ""
+                    let canShowButton = !viewModel.isLoading && !buttonTitle.isEmpty
+
+                    StyledButton(
+                        buttonTitle,
+                        action: {
+                            Task {
+                                await viewModel.proceed()
+                            }
+                        },
+                        color: Theme.Colors.accentButtonColor,
+                        textColor: Theme.Colors.styledButtonText,
+                        isTitleTracking: false,
+                        isLimitedOnPad: false
+                    )
+                    .opacity(canShowButton ? 1 : 0)
+                    .disabled(!canShowButton)
+
+                    ProgressBar(size: 30, lineWidth: 8)
+                        .opacity(canShowButton ? 0 : 1)
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
+            }
+            .background {
+                Theme.Colors.background
+                    .ignoresSafeArea()
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        if !viewModel.interactiveDismissDisabled {
+                            viewModel.dismiss()
+                        }
+                    } label: {
+                        Image(systemName: "xmark")
+                            .foregroundColor(Theme.Colors.accentColor)
+                    }
+                    .accessibilityIdentifier("close_button")
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+        .interactiveDismissDisabled(viewModel.interactiveDismissDisabled)
+        .task {
+            await viewModel.fetchProduct()
+        }
+        .onFirstAppear {
+            viewModel.trackScreenViewed()
+        }
+    }
+
+    @ViewBuilder
+    private var scrollView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // Titles
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("\(CoreLocalization.CourseUpgrade.View.title) \(viewModel.productName)")
+                        .font(Theme.Fonts.titleLarge)
+                        .lineLimit(3)
+                        .truncationMode(.tail)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Text(CoreLocalization.TrackSelection.View.title)
+                        .font(Theme.Fonts.titleLarge)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .foregroundColor(Theme.Colors.textPrimary)
+
+                // Cards
+                adaptiveStack(
+                    spacing: 8,
+                    isHorizontal: isHorizontal
+                ) {
+                    ForEach(viewModel.cards, id: \.key) { card in
+                        let key = card.key
+                        let info = card.value
+
+                        Button(
+                            action: {
+                                viewModel.cardPressed(key)
+                            },
+                            label: {
+                                TrackCardView(
+                                    heading: info.heading,
+                                    subheading: info.subheading,
+                                    paragraphs: info.paragraphs,
+                                    isSelected: viewModel.selectedCard == key
+                                )
+                            }
+                        )
+                    }
+                }
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    TrackSelectionView(
+        viewModel: TrackSelectionViewModel(
+            courseID: "",
+            productName: "Preview",
+            screen: .dashboard,
+            sku: "SKU",
+            pacing: "self",
+            lmsPrice: .zero,
+            accessExpires: Date(),
+            handler: CourseUpgradeHandlerProtocolMock(),
+            analytics: CoreAnalyticsMock(),
+            router: BaseRouterMock()
+        )
+    )
+}
+#endif

--- a/Core/Core/CourseUpgrade/ViewModels/TrackSelectionViewModel.swift
+++ b/Core/Core/CourseUpgrade/ViewModels/TrackSelectionViewModel.swift
@@ -1,0 +1,190 @@
+//
+//  TrackSelectionViewModel.swift
+//  Core
+//
+//  Created by Muhammad Tayyab Akram on 5/5/25.
+//
+
+import Foundation
+import Combine
+
+public final class TrackSelectionViewModel: ObservableObject {
+    typealias Cards = KeyValuePairs<TrackCardKey, TrackCardInfo>
+
+    @Published private(set) var cards: Cards = [:]
+    @Published private(set) var selectedCard: TrackCardKey?
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var interactiveDismissDisabled = false
+
+    private(set) var continueTitle: String?
+
+    private let accessExpires: Date
+    private let analytics: CoreAnalytics
+    private let router: BaseRouter
+    private let upgradeViewModel: UpgradeInfoViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    var productName: String { upgradeViewModel.productName }
+
+    public init(
+        courseID: String,
+        productName: String,
+        screen: CourseUpgradeScreen,
+        sku: String,
+        pacing: String,
+        lmsPrice: Double,
+        accessExpires: Date,
+        handler: CourseUpgradeHandlerProtocol,
+        analytics: CoreAnalytics,
+        router: BaseRouter
+    ) {
+        self.accessExpires = accessExpires
+        self.analytics = analytics
+        self.router = router
+        self.upgradeViewModel = UpgradeInfoViewModel(
+            productName: productName,
+            message: "",
+            sku: sku,
+            courseID: courseID,
+            screen: screen,
+            handler: handler,
+            pacing: pacing,
+            analytics: analytics,
+            router: router,
+            lmsPrice: lmsPrice
+        )
+
+        upgradeViewModel.$isLoading
+            .sink { [weak self] isLoading in
+                guard let self else { return }
+
+                Task { @MainActor in
+                    self.isLoading = isLoading
+                    self.updateCards()
+                    self.refreshContinueTitle()
+                }
+            }
+            .store(in: &cancellables)
+
+        upgradeViewModel.$interactiveDismissDisabled
+            .assign(to: &$interactiveDismissDisabled)
+
+        upgradeViewModel.$error
+            .sink { [weak self] error in
+                guard let self else { return }
+
+                if error != nil {
+                    Task {
+                        await self.dismiss()
+                    }
+                }
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default
+            .publisher(for: .courseUpgradeCompletionNotification)
+            .sink { [weak self] _ in
+                guard let self else { return }
+
+                Task {
+                    await self.dismiss()
+                }
+            }
+            .store(in: &cancellables)
+
+        selectCard(.certificate)
+    }
+
+    func cardPressed(_ key: TrackCardKey) {
+        selectCard(key)
+    }
+
+    func fetchProduct() async {
+        await upgradeViewModel.fetchProduct()
+    }
+
+    @MainActor
+    func proceed() async {
+        switch selectedCard {
+        case .certificate:
+            await upgradeViewModel.purchase(mode: .trackSelection)
+        case .free:
+            trackContinueWithFreeTrackClicked()
+            dismiss()
+        case .none: break
+        }
+    }
+
+    @MainActor
+    func dismiss() {
+        router.dismiss()
+    }
+
+    private func updateCards() {
+        let expiresAt = accessExpires.dateToString(style: .monthDay)
+
+        cards = [
+            .certificate: TrackCardInfo(
+                heading: (
+                    upgradeViewModel.price.isEmpty
+                        ? CoreLocalization.TrackSelection.Card.earnCertificateHeading
+                        : CoreLocalization.TrackSelection.Card
+                            .earnCertificateWithPriceHeading(upgradeViewModel.price)
+                ),
+                subheading: "",
+                description: CoreLocalization.TrackSelection.Card.earnCertificateDescription
+            ),
+            .free: TrackCardInfo(
+                heading: CoreLocalization.TrackSelection.Card.accessCourseHeading,
+                subheading: CoreLocalization.TrackSelection.Card
+                    .accessCourseSubheading(expiresAt),
+                description: CoreLocalization.TrackSelection.Card
+                    .accessCourseDescription(expiresAt)
+            )
+        ]
+    }
+
+    private func selectCard(_ key: TrackCardKey) {
+        selectedCard = key
+        refreshContinueTitle()
+    }
+
+    private func refreshContinueTitle() {
+        switch selectedCard {
+        case .certificate:
+            if upgradeViewModel.price.isEmpty {
+                continueTitle = nil
+            } else {
+                continueTitle = CoreLocalization.TrackSelection.Button
+                    .continueToPayment(upgradeViewModel.price)
+            }
+        case .free:
+            continueTitle = CoreLocalization.TrackSelection.Button.continueWithFreeTrack
+        case .none:
+            continueTitle = nil
+        }
+    }
+
+    func trackScreenViewed() {
+        analytics.trackSelectionViewed(
+            courseID: upgradeViewModel.courseID,
+            pacing: upgradeViewModel.pacing,
+            lmsPrice: upgradeViewModel.lmsPrice,
+            screen: upgradeViewModel.screen
+        )
+    }
+
+    func trackContinueWithFreeTrackClicked() {
+        analytics.trackContinueWithFreeTrackClicked(
+            courseID: upgradeViewModel.courseID,
+            pacing: upgradeViewModel.pacing,
+            lmsPrice: upgradeViewModel.lmsPrice,
+            screen: upgradeViewModel.screen
+        )
+    }
+}
+
+enum TrackCardKey {
+    case certificate
+    case free
+}

--- a/Core/Core/CourseUpgrade/ViewModels/UpgradeInfoViewModel.swift
+++ b/Core/Core/CourseUpgrade/ViewModels/UpgradeInfoViewModel.swift
@@ -18,7 +18,9 @@ public class UpgradeInfoViewModel: ObservableObject {
     let analytics: CoreAnalytics
     let router: BaseRouter
     let lmsPrice: Double
-    
+
+    private var mode: UpgradeMode = .userInitiated
+
     @Published var isLoading: Bool = false
     @Published var product: StoreProductInfo?
     @Published var error: Error?
@@ -102,7 +104,7 @@ public class UpgradeInfoViewModel: ObservableObject {
                         alertType: .priceFetch,
                         errorAction: UpgradeErrorAction.reloadPrice.rawValue,
                         error: "price",
-                        flowType: .userInitiated
+                        flowType: mode
                     )
                 }
             )
@@ -128,7 +130,7 @@ public class UpgradeInfoViewModel: ObservableObject {
                     alertType: .priceFetch,
                     errorAction: UpgradeErrorAction.close.rawValue,
                     error: "price",
-                    flowType: .userInitiated
+                    flowType: mode
                 )
             }
         )
@@ -139,7 +141,9 @@ public class UpgradeInfoViewModel: ObservableObject {
         )
     }
 
-    public func purchase() async {
+    @MainActor
+    public func purchase(mode: UpgradeMode = .userInitiated) async {
+        self.mode = mode
         isLoading = true
         interactiveDismissDisabled = true
         analytics.trackUpgradeNow(
@@ -153,7 +157,7 @@ public class UpgradeInfoViewModel: ObservableObject {
         )
         await handler.upgradeCourse(
             sku: sku,
-            mode: .userInitiated,
+            mode: mode,
             productInfo: product,
             pacing: pacing,
             courseID: courseID,

--- a/Core/Core/SwiftGen/Strings.swift
+++ b/Core/Core/SwiftGen/Strings.swift
@@ -381,6 +381,41 @@ public enum CoreLocalization {
     /// Sign in
     public static let logInBtn = CoreLocalization.tr("Localizable", "SIGN_IN.LOG_IN_BTN", fallback: "Sign in")
   }
+  public enum TrackSelection {
+    public enum Button {
+      /// Continue to payment (%@)
+      public static func continueToPayment(_ p1: Any) -> String {
+        return CoreLocalization.tr("Localizable", "TRACK_SELECTION.BUTTON.CONTINUE_TO_PAYMENT", String(describing: p1), fallback: "Continue to payment (%@)")
+      }
+      /// Continue with free track
+      public static let continueWithFreeTrack = CoreLocalization.tr("Localizable", "TRACK_SELECTION.BUTTON.CONTINUE_WITH_FREE_TRACK", fallback: "Continue with free track")
+    }
+    public enum Card {
+      /// Limited access to non-graded activities and course material. Your progress and all access will be lost after %@
+      public static func accessCourseDescription(_ p1: Any) -> String {
+        return CoreLocalization.tr("Localizable", "TRACK_SELECTION.CARD.ACCESS_COURSE_DESCRIPTION", String(describing: p1), fallback: "Limited access to non-graded activities and course material. Your progress and all access will be lost after %@")
+      }
+      /// Access this course
+      public static let accessCourseHeading = CoreLocalization.tr("Localizable", "TRACK_SELECTION.CARD.ACCESS_COURSE_HEADING", fallback: "Access this course")
+      /// Access expires %@
+      public static func accessCourseSubheading(_ p1: Any) -> String {
+        return CoreLocalization.tr("Localizable", "TRACK_SELECTION.CARD.ACCESS_COURSE_SUBHEADING", String(describing: p1), fallback: "Access expires %@")
+      }
+      /// Get access to all graded course activities and course materials, even after the course ends.
+      /// Earn a verified certificate of completion.
+      public static let earnCertificateDescription = CoreLocalization.tr("Localizable", "TRACK_SELECTION.CARD.EARN_CERTIFICATE_DESCRIPTION", fallback: "Get access to all graded course activities and course materials, even after the course ends.\nEarn a verified certificate of completion.")
+      /// Earn a certificate
+      public static let earnCertificateHeading = CoreLocalization.tr("Localizable", "TRACK_SELECTION.CARD.EARN_CERTIFICATE_HEADING", fallback: "Earn a certificate")
+      /// Earn a certificate for %@
+      public static func earnCertificateWithPriceHeading(_ p1: Any) -> String {
+        return CoreLocalization.tr("Localizable", "TRACK_SELECTION.CARD.EARN_CERTIFICATE_WITH_PRICE_HEADING", String(describing: p1), fallback: "Earn a certificate for %@")
+      }
+    }
+    public enum View {
+      /// Choose a path.
+      public static let title = CoreLocalization.tr("Localizable", "TRACK_SELECTION.VIEW.TITLE", fallback: "Choose a path.")
+    }
+  }
   public enum View {
     public enum Snackbar {
       /// Try Again

--- a/Core/Core/en.lproj/Localizable.strings
+++ b/Core/Core/en.lproj/Localizable.strings
@@ -182,3 +182,13 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired %@";
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on %@";
 "COURSE.SOON" = "Soon";
+
+"TRACK_SELECTION.VIEW.TITLE" = "Choose a path.";
+"TRACK_SELECTION.CARD.EARN_CERTIFICATE_HEADING" = "Earn a certificate";
+"TRACK_SELECTION.CARD.EARN_CERTIFICATE_WITH_PRICE_HEADING" = "Earn a certificate for %@";
+"TRACK_SELECTION.CARD.EARN_CERTIFICATE_DESCRIPTION" = "Get access to all graded course activities and course materials, even after the course ends.\nEarn a verified certificate of completion.";
+"TRACK_SELECTION.CARD.ACCESS_COURSE_HEADING" = "Access this course";
+"TRACK_SELECTION.CARD.ACCESS_COURSE_SUBHEADING" = "Access expires %@";
+"TRACK_SELECTION.CARD.ACCESS_COURSE_DESCRIPTION" = "Limited access to non-graded activities and course material. Your progress and all access will be lost after %@";
+"TRACK_SELECTION.BUTTON.CONTINUE_WITH_FREE_TRACK" = "Continue with free track";
+"TRACK_SELECTION.BUTTON.CONTINUE_TO_PAYMENT" = "Continue to payment (%@)";

--- a/Core/Core/uk.lproj/Localizable.strings
+++ b/Core/Core/uk.lproj/Localizable.strings
@@ -153,3 +153,13 @@
 "COURSE_UPGRADE.UNLOCKING_TEXT"= "Unlocking ";
 "COURSE_UPGRADE.UNLOCKING_FULL_ACCESS"= "full access ";
 "COURSE_UPGRADE.UNLOCKING_TO_COURSE"= "to your course";
+
+"TRACK_SELECTION.VIEW.TITLE" = "Choose a path.";
+"TRACK_SELECTION.CARD.EARN_CERTIFICATE_HEADING" = "Earn a certificate";
+"TRACK_SELECTION.CARD.EARN_CERTIFICATE_WITH_PRICE_HEADING" = "Earn a certificate for %@";
+"TRACK_SELECTION.CARD.EARN_CERTIFICATE_DESCRIPTION" = "Get access to all graded course activities and course materials, even after the course ends.\nEarn a verified certificate of completion.";
+"TRACK_SELECTION.CARD.ACCESS_COURSE_HEADING" = "Access this course";
+"TRACK_SELECTION.CARD.ACCESS_COURSE_SUBHEADING" = "Access expires %@";
+"TRACK_SELECTION.CARD.ACCESS_COURSE_DESCRIPTION" = "Limited access to non-graded activities and course material. Your progress and all access will be lost after %@";
+"TRACK_SELECTION.BUTTON.CONTINUE_WITH_FREE_TRACK" = "Continue with free track";
+"TRACK_SELECTION.BUTTON.CONTINUE_TO_PAYMENT" = "Continue to payment (%@)";

--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -107,6 +107,7 @@ public class CourseContainerViewModel: BaseCourseViewModel {
     let coreAnalytics: CoreAnalytics
     private(set) var storage: CourseStorage
     private var courseID: String?
+    private var canShowTrackSelection: Bool
     let serverConfig: ServerConfigProtocol
     
     public init(
@@ -126,6 +127,7 @@ public class CourseContainerViewModel: BaseCourseViewModel {
         lastVisitedBlockID: String?,
         coreAnalytics: CoreAnalytics,
         selection: CourseTab = CourseTab.course,
+        showTrackSelection: Bool = false,
         serverConfig: ServerConfigProtocol
     ) {
         self.interactor = interactor
@@ -145,6 +147,7 @@ public class CourseContainerViewModel: BaseCourseViewModel {
         self.lastVisitedBlockID = lastVisitedBlockID
         self.coreAnalytics = coreAnalytics
         self.selection = selection.rawValue
+        self.canShowTrackSelection = showTrackSelection
         self.serverConfig = serverConfig
         
         super.init(manager: manager)
@@ -245,7 +248,12 @@ public class CourseContainerViewModel: BaseCourseViewModel {
             shouldShowUpgradeButton = type == nil 
             && courseStructure?.isUpgradeable ?? false
             && serverConfig.iapConfig.enabled
-            
+
+            if shouldShowUpgradeButton && canShowTrackSelection {
+                showTrackSelection()
+            }
+            canShowTrackSelection = false
+
             updateMenuBarVisibility()
 
             if isInternetAvaliable {
@@ -433,6 +441,25 @@ public class CourseContainerViewModel: BaseCourseViewModel {
         }
 
         await download(state: state, blocks: blocks)
+    }
+
+    @MainActor
+    func showTrackSelection() {
+        guard let structure = courseStructure,
+              let sku = courseStructure?.sku,
+              let lmsPrice = courseStructure?.lmsPrice,
+              let accessExpires = date(from: structure.coursewareAccessDetails?.auditAccessExpires)
+        else { return }
+
+        router.showTrackSelection(
+            courseID: structure.id,
+            productName: structure.displayName,
+            screen: .courseDashboard,
+            sku: sku,
+            pacing: structure.isSelfPaced ? Pacing.selfPace.rawValue : Pacing.instructor.rawValue,
+            lmsPrice: lmsPrice,
+            accessExpires: accessExpires
+        )
     }
 
     func showPaymentsInfo() {

--- a/Course/CourseTests/CourseMock.generated.swift
+++ b/Course/CourseTests/CourseMock.generated.swift
@@ -612,6 +612,13 @@ open class BaseRouterMock: BaseRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -699,6 +706,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -810,6 +818,17 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -873,6 +892,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -904,6 +924,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -949,6 +970,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -1024,6 +1047,10 @@ open class BaseRouterMock: BaseRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {
@@ -1469,6 +1496,18 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
     }
 
+    open func trackSelectionViewed(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
+    open func trackContinueWithFreeTrackClicked(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
     open func trackEvent(_ event: AnalyticsEvent) {
         addInvocation(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`)))
 		let perform = methodPerformValue(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`))) as? (AnalyticsEvent) -> Void
@@ -1510,6 +1549,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         case m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeMode>)
         case m_trackRestorePurchaseClicked
         case m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
         case m_trackEvent__event(Parameter<AnalyticsEvent>)
         case m_trackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_trackScreenEvent__event(Parameter<AnalyticsEvent>)
@@ -1650,6 +1691,22 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_trackEvent__event(let lhsEvent), .m_trackEvent__event(let rhsEvent)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
@@ -1692,6 +1749,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case let .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case .m_trackRestorePurchaseClicked: return 0
             case let .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case let .m_trackEvent__event(p0): return p0.intValue
             case let .m_trackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_trackScreenEvent__event(p0): return p0.intValue
@@ -1715,6 +1774,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType: return ".trackCourseUnfulfilledPurchaseInitiated(courseID:pacing:screen:flowType:)"
             case .m_trackRestorePurchaseClicked: return ".trackRestorePurchaseClicked()"
             case .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackValuePropViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackSelectionViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackContinueWithFreeTrackClicked(courseID:pacing:lmsPrice:screen:)"
             case .m_trackEvent__event: return ".trackEvent(_:)"
             case .m_trackEvent__eventbiValue_biValue: return ".trackEvent(_:biValue:)"
             case .m_trackScreenEvent__event: return ".trackScreenEvent(_:)"
@@ -1752,6 +1813,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         public static func trackCourseUnfulfilledPurchaseInitiated(courseID: Parameter<String>, pacing: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, flowType: Parameter<UpgradeMode>) -> Verify { return Verify(method: .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(`courseID`, `pacing`, `screen`, `flowType`))}
         public static func trackRestorePurchaseClicked() -> Verify { return Verify(method: .m_trackRestorePurchaseClicked)}
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackEvent__event(`event`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_trackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func trackScreenEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackScreenEvent__event(`event`))}
@@ -1806,6 +1869,12 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         }
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
             return Perform(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
         }
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, perform: @escaping (AnalyticsEvent) -> Void) -> Perform {
             return Perform(method: .m_trackEvent__event(`event`), performs: perform)

--- a/Dashboard/Dashboard/Presentation/AllCoursesView.swift
+++ b/Dashboard/Dashboard/Presentation/AllCoursesView.swift
@@ -81,7 +81,8 @@ public struct AllCoursesView: View {
                                                 courseRawImage: course.imageURL,
                                                 coursewareAccess: course.coursewareAccess,
                                                 showDates: false,
-                                                lastVisitedBlockID: nil
+                                                lastVisitedBlockID: nil,
+                                                showTrackSelection: false
                                             )
                                         }, label: {
                                             CourseCardView(

--- a/Dashboard/Dashboard/Presentation/DashboardRouter.swift
+++ b/Dashboard/Dashboard/Presentation/DashboardRouter.swift
@@ -21,7 +21,8 @@ public protocol DashboardRouter: BaseRouter {
                            courseRawImage: String?,
                            coursewareAccess: CoursewareAccess?,
                            showDates: Bool,
-                           lastVisitedBlockID: String?
+                           lastVisitedBlockID: String?,
+                           showTrackSelection: Bool
     )
     
     func showAllCourses(courses: [CourseItem])
@@ -47,8 +48,9 @@ public class DashboardRouterMock: BaseRouterMock, DashboardRouter {
                                   courseRawImage: String?,
                                   coursewareAccess: CoursewareAccess?,
                                   showDates: Bool,
-                                  lastVisitedBlockID: String?) {}
-    
+                                  lastVisitedBlockID: String?,
+                                  showTrackSelection: Bool) {}
+
     public func showAllCourses(courses: [CourseItem]) {}
     
     public func showDiscoverySearch(searchQuery: String?) {}

--- a/Dashboard/Dashboard/Presentation/DashboardRouter.swift
+++ b/Dashboard/Dashboard/Presentation/DashboardRouter.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Core
 
+// swiftlint:disable function_parameter_count
 public protocol DashboardRouter: BaseRouter {
     
     func showCourseScreens(courseID: String,
@@ -58,3 +59,4 @@ public class DashboardRouterMock: BaseRouterMock, DashboardRouter {
     public func showSettings() {}
 }
 #endif
+// swiftlint:enable function_parameter_count

--- a/Dashboard/Dashboard/Presentation/ListDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/ListDashboardView.swift
@@ -101,7 +101,8 @@ public struct ListDashboardView: View {
                                                 courseRawImage: course.courseRawImage,
                                                 coursewareAccess: course.coursewareAccess,
                                                 showDates: false,
-                                                lastVisitedBlockID: nil
+                                                lastVisitedBlockID: nil,
+                                                showTrackSelection: false
                                             )
                                         }
                                         .accessibilityIdentifier("course_item")

--- a/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
@@ -114,7 +114,8 @@ public struct PrimaryCourseDashboardView<ProgramView: View, TopBarButtons: View>
                                                             courseRawImage: primary.courseBanner,
                                                             coursewareAccess: nil,
                                                             showDates: assignmentData.lastVisitedBlockID == nil,
-                                                            lastVisitedBlockID: assignmentData.lastVisitedBlockID
+                                                            lastVisitedBlockID: assignmentData.lastVisitedBlockID,
+                                                            showTrackSelection: false
                                                         )
                                                     },
                                                     openCourseAction: {
@@ -135,7 +136,8 @@ public struct PrimaryCourseDashboardView<ProgramView: View, TopBarButtons: View>
                                                             courseRawImage: primary.courseBanner,
                                                             coursewareAccess: nil,
                                                             showDates: false,
-                                                            lastVisitedBlockID: nil
+                                                            lastVisitedBlockID: nil,
+                                                            showTrackSelection: false
                                                         )
                                                     },
                                                     resumeAction: {
@@ -156,7 +158,8 @@ public struct PrimaryCourseDashboardView<ProgramView: View, TopBarButtons: View>
                                                             courseRawImage: primary.courseBanner,
                                                             coursewareAccess: nil,
                                                             showDates: false,
-                                                            lastVisitedBlockID: primary.lastVisitedBlockID
+                                                            lastVisitedBlockID: primary.lastVisitedBlockID,
+                                                            showTrackSelection: false
                                                         )
                                                     },
                                                     isUpgradeable: primary.isUpgradeable &&
@@ -286,7 +289,8 @@ public struct PrimaryCourseDashboardView<ProgramView: View, TopBarButtons: View>
                     courseRawImage: course.imageURL,
                     coursewareAccess: course.coursewareAccess,
                     showDates: false,
-                    lastVisitedBlockID: nil
+                    lastVisitedBlockID: nil,
+                    showTrackSelection: false
                 )
             }, label: {
                 CourseCardView(

--- a/Dashboard/DashboardTests/DashboardMock.generated.swift
+++ b/Dashboard/DashboardTests/DashboardMock.generated.swift
@@ -612,6 +612,13 @@ open class BaseRouterMock: BaseRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -699,6 +706,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -810,6 +818,17 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -873,6 +892,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -904,6 +924,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -949,6 +970,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -1024,6 +1047,10 @@ open class BaseRouterMock: BaseRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {
@@ -1469,6 +1496,18 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
     }
 
+    open func trackSelectionViewed(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
+    open func trackContinueWithFreeTrackClicked(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
     open func trackEvent(_ event: AnalyticsEvent) {
         addInvocation(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`)))
 		let perform = methodPerformValue(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`))) as? (AnalyticsEvent) -> Void
@@ -1510,6 +1549,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         case m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeMode>)
         case m_trackRestorePurchaseClicked
         case m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
         case m_trackEvent__event(Parameter<AnalyticsEvent>)
         case m_trackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_trackScreenEvent__event(Parameter<AnalyticsEvent>)
@@ -1650,6 +1691,22 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_trackEvent__event(let lhsEvent), .m_trackEvent__event(let rhsEvent)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
@@ -1692,6 +1749,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case let .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case .m_trackRestorePurchaseClicked: return 0
             case let .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case let .m_trackEvent__event(p0): return p0.intValue
             case let .m_trackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_trackScreenEvent__event(p0): return p0.intValue
@@ -1715,6 +1774,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType: return ".trackCourseUnfulfilledPurchaseInitiated(courseID:pacing:screen:flowType:)"
             case .m_trackRestorePurchaseClicked: return ".trackRestorePurchaseClicked()"
             case .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackValuePropViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackSelectionViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackContinueWithFreeTrackClicked(courseID:pacing:lmsPrice:screen:)"
             case .m_trackEvent__event: return ".trackEvent(_:)"
             case .m_trackEvent__eventbiValue_biValue: return ".trackEvent(_:biValue:)"
             case .m_trackScreenEvent__event: return ".trackScreenEvent(_:)"
@@ -1752,6 +1813,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         public static func trackCourseUnfulfilledPurchaseInitiated(courseID: Parameter<String>, pacing: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, flowType: Parameter<UpgradeMode>) -> Verify { return Verify(method: .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(`courseID`, `pacing`, `screen`, `flowType`))}
         public static func trackRestorePurchaseClicked() -> Verify { return Verify(method: .m_trackRestorePurchaseClicked)}
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackEvent__event(`event`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_trackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func trackScreenEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackScreenEvent__event(`event`))}
@@ -1806,6 +1869,12 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         }
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
             return Perform(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
         }
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, perform: @escaping (AnalyticsEvent) -> Void) -> Perform {
             return Perform(method: .m_trackEvent__event(`event`), performs: perform)

--- a/Discovery/Discovery/Presentation/DiscoveryRouter.swift
+++ b/Discovery/Discovery/Presentation/DiscoveryRouter.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Core
 
+// swiftlint:disable function_parameter_count
 public protocol DiscoveryRouter: BaseRouter {
     func showCourseDetais(courseID: String, title: String)
     func showWebDiscoveryDetails(
@@ -77,3 +78,4 @@ public class DiscoveryRouterMock: BaseRouterMock, DiscoveryRouter {
     ) {}
 }
 #endif
+// swiftlint:enable function_parameter_count

--- a/Discovery/Discovery/Presentation/DiscoveryRouter.swift
+++ b/Discovery/Discovery/Presentation/DiscoveryRouter.swift
@@ -30,7 +30,8 @@ public protocol DiscoveryRouter: BaseRouter {
         courseRawImage: String?,
         coursewareAccess: CoursewareAccess?,
         showDates: Bool,
-        lastVisitedBlockID: String?
+        lastVisitedBlockID: String?,
+        showTrackSelection: Bool
     )
     
     func showWebProgramDetails(
@@ -66,7 +67,8 @@ public class DiscoveryRouterMock: BaseRouterMock, DiscoveryRouter {
         courseRawImage: String?,
         coursewareAccess: CoursewareAccess?,
         showDates: Bool,
-        lastVisitedBlockID: String?
+        lastVisitedBlockID: String?,
+        showTrackSelection: Bool
     ) {}
     
     public func showWebProgramDetails(

--- a/Discovery/Discovery/Presentation/NativeDiscovery/CourseDetailsView.swift
+++ b/Discovery/Discovery/Presentation/NativeDiscovery/CourseDetailsView.swift
@@ -285,7 +285,8 @@ private struct CourseStateView: View {
                         courseRawImage: courseDetails.courseRawImage,
                         coursewareAccess: nil,
                         showDates: false,
-                        lastVisitedBlockID: nil
+                        lastVisitedBlockID: nil,
+                        showTrackSelection: false
                     )
                 }
             })

--- a/Discovery/Discovery/Presentation/WebDiscovery/DiscoveryWebviewViewModel.swift
+++ b/Discovery/Discovery/Presentation/WebDiscovery/DiscoveryWebviewViewModel.swift
@@ -85,7 +85,7 @@ public class DiscoveryWebviewViewModel: ObservableObject {
             courseDetails?.isEnrolled = true
             showProgress = false
             NotificationCenter.default.post(name: .onCourseEnrolled, object: courseID)
-            showCourseDetails()
+            showCourseDetails(showTrackSelection: true)
         } catch let error {
             showProgress = false
             if error.isInternetError || error is NoCachedDataError {
@@ -241,7 +241,7 @@ extension DiscoveryWebviewViewModel: WebViewNavigationDelegate {
         return path
     }
     
-    @discardableResult private func showCourseDetails() -> Bool {
+    @discardableResult private func showCourseDetails(showTrackSelection: Bool = false) -> Bool {
         guard let courseDetails = courseDetails else { return false }
         
         router.showCourseScreens(
@@ -256,7 +256,8 @@ extension DiscoveryWebviewViewModel: WebViewNavigationDelegate {
             courseRawImage: courseDetails.courseRawImage,
             coursewareAccess: nil,
             showDates: false,
-            lastVisitedBlockID: nil
+            lastVisitedBlockID: nil,
+            showTrackSelection: showTrackSelection
         )
         
         return true

--- a/Discovery/Discovery/Presentation/WebPrograms/ProgramWebviewViewModel.swift
+++ b/Discovery/Discovery/Presentation/WebPrograms/ProgramWebviewViewModel.swift
@@ -73,7 +73,7 @@ public class ProgramWebviewViewModel: ObservableObject, WebviewCookiesUpdateProt
             courseDetails?.isEnrolled = true
             showProgress = false
             NotificationCenter.default.post(name: .onCourseEnrolled, object: courseID)
-            showCourseDetails()
+            showCourseDetails(showTrackSelection: true)
             courseDetails = nil
         } catch let error {
             showProgress = false
@@ -215,7 +215,7 @@ extension ProgramWebviewViewModel: WebViewNavigationDelegate {
         return (courseId, emailOptIn ?? false)
     }
     
-    @discardableResult private func showCourseDetails() -> Bool {
+    @discardableResult private func showCourseDetails(showTrackSelection: Bool = false) -> Bool {
         guard let courseDetails = courseDetails else { return false }
         
         router.showCourseScreens(
@@ -230,7 +230,8 @@ extension ProgramWebviewViewModel: WebViewNavigationDelegate {
             courseRawImage: courseDetails.courseRawImage,
             coursewareAccess: nil,
             showDates: false,
-            lastVisitedBlockID: nil
+            lastVisitedBlockID: nil,
+            showTrackSelection: showTrackSelection
         )
         
         return true

--- a/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
+++ b/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
@@ -612,6 +612,13 @@ open class BaseRouterMock: BaseRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -699,6 +706,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -810,6 +818,17 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -873,6 +892,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -904,6 +924,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -949,6 +970,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -1024,6 +1047,10 @@ open class BaseRouterMock: BaseRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {
@@ -1469,6 +1496,18 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
     }
 
+    open func trackSelectionViewed(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
+    open func trackContinueWithFreeTrackClicked(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
     open func trackEvent(_ event: AnalyticsEvent) {
         addInvocation(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`)))
 		let perform = methodPerformValue(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`))) as? (AnalyticsEvent) -> Void
@@ -1510,6 +1549,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         case m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeMode>)
         case m_trackRestorePurchaseClicked
         case m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
         case m_trackEvent__event(Parameter<AnalyticsEvent>)
         case m_trackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_trackScreenEvent__event(Parameter<AnalyticsEvent>)
@@ -1650,6 +1691,22 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_trackEvent__event(let lhsEvent), .m_trackEvent__event(let rhsEvent)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
@@ -1692,6 +1749,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case let .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case .m_trackRestorePurchaseClicked: return 0
             case let .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case let .m_trackEvent__event(p0): return p0.intValue
             case let .m_trackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_trackScreenEvent__event(p0): return p0.intValue
@@ -1715,6 +1774,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType: return ".trackCourseUnfulfilledPurchaseInitiated(courseID:pacing:screen:flowType:)"
             case .m_trackRestorePurchaseClicked: return ".trackRestorePurchaseClicked()"
             case .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackValuePropViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackSelectionViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackContinueWithFreeTrackClicked(courseID:pacing:lmsPrice:screen:)"
             case .m_trackEvent__event: return ".trackEvent(_:)"
             case .m_trackEvent__eventbiValue_biValue: return ".trackEvent(_:biValue:)"
             case .m_trackScreenEvent__event: return ".trackScreenEvent(_:)"
@@ -1752,6 +1813,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         public static func trackCourseUnfulfilledPurchaseInitiated(courseID: Parameter<String>, pacing: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, flowType: Parameter<UpgradeMode>) -> Verify { return Verify(method: .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(`courseID`, `pacing`, `screen`, `flowType`))}
         public static func trackRestorePurchaseClicked() -> Verify { return Verify(method: .m_trackRestorePurchaseClicked)}
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackEvent__event(`event`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_trackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func trackScreenEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackScreenEvent__event(`event`))}
@@ -1806,6 +1869,12 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         }
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
             return Perform(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
         }
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, perform: @escaping (AnalyticsEvent) -> Void) -> Perform {
             return Perform(method: .m_trackEvent__event(`event`), performs: perform)

--- a/Discussion/DiscussionTests/DiscussionMock.generated.swift
+++ b/Discussion/DiscussionTests/DiscussionMock.generated.swift
@@ -612,6 +612,13 @@ open class BaseRouterMock: BaseRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -699,6 +706,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -810,6 +818,17 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -873,6 +892,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -904,6 +924,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -949,6 +970,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -1024,6 +1047,10 @@ open class BaseRouterMock: BaseRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {
@@ -1469,6 +1496,18 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
     }
 
+    open func trackSelectionViewed(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
+    open func trackContinueWithFreeTrackClicked(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
     open func trackEvent(_ event: AnalyticsEvent) {
         addInvocation(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`)))
 		let perform = methodPerformValue(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`))) as? (AnalyticsEvent) -> Void
@@ -1510,6 +1549,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         case m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeMode>)
         case m_trackRestorePurchaseClicked
         case m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
         case m_trackEvent__event(Parameter<AnalyticsEvent>)
         case m_trackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_trackScreenEvent__event(Parameter<AnalyticsEvent>)
@@ -1650,6 +1691,22 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_trackEvent__event(let lhsEvent), .m_trackEvent__event(let rhsEvent)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
@@ -1692,6 +1749,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case let .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case .m_trackRestorePurchaseClicked: return 0
             case let .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case let .m_trackEvent__event(p0): return p0.intValue
             case let .m_trackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_trackScreenEvent__event(p0): return p0.intValue
@@ -1715,6 +1774,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType: return ".trackCourseUnfulfilledPurchaseInitiated(courseID:pacing:screen:flowType:)"
             case .m_trackRestorePurchaseClicked: return ".trackRestorePurchaseClicked()"
             case .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackValuePropViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackSelectionViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackContinueWithFreeTrackClicked(courseID:pacing:lmsPrice:screen:)"
             case .m_trackEvent__event: return ".trackEvent(_:)"
             case .m_trackEvent__eventbiValue_biValue: return ".trackEvent(_:biValue:)"
             case .m_trackScreenEvent__event: return ".trackScreenEvent(_:)"
@@ -1752,6 +1813,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         public static func trackCourseUnfulfilledPurchaseInitiated(courseID: Parameter<String>, pacing: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, flowType: Parameter<UpgradeMode>) -> Verify { return Verify(method: .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(`courseID`, `pacing`, `screen`, `flowType`))}
         public static func trackRestorePurchaseClicked() -> Verify { return Verify(method: .m_trackRestorePurchaseClicked)}
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackEvent__event(`event`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_trackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func trackScreenEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackScreenEvent__event(`event`))}
@@ -1806,6 +1869,12 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         }
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
             return Perform(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
         }
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, perform: @escaping (AnalyticsEvent) -> Void) -> Perform {
             return Perform(method: .m_trackEvent__event(`event`), performs: perform)
@@ -4081,6 +4150,13 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -4180,6 +4256,7 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -4339,6 +4416,17 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -4416,6 +4504,7 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -4454,6 +4543,7 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -4506,6 +4596,8 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -4600,6 +4692,10 @@ open class DiscussionRouterMock: DiscussionRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {

--- a/Notifications/NotificationsTests/NotificationsMock.generated.swift
+++ b/Notifications/NotificationsTests/NotificationsMock.generated.swift
@@ -612,6 +612,13 @@ open class BaseRouterMock: BaseRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -699,6 +706,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -810,6 +818,17 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -873,6 +892,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -904,6 +924,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -949,6 +970,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -1024,6 +1047,10 @@ open class BaseRouterMock: BaseRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {
@@ -1469,6 +1496,18 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
     }
 
+    open func trackSelectionViewed(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
+    open func trackContinueWithFreeTrackClicked(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
     open func trackEvent(_ event: AnalyticsEvent) {
         addInvocation(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`)))
 		let perform = methodPerformValue(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`))) as? (AnalyticsEvent) -> Void
@@ -1510,6 +1549,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         case m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeMode>)
         case m_trackRestorePurchaseClicked
         case m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
         case m_trackEvent__event(Parameter<AnalyticsEvent>)
         case m_trackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_trackScreenEvent__event(Parameter<AnalyticsEvent>)
@@ -1650,6 +1691,22 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_trackEvent__event(let lhsEvent), .m_trackEvent__event(let rhsEvent)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
@@ -1692,6 +1749,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case let .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case .m_trackRestorePurchaseClicked: return 0
             case let .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case let .m_trackEvent__event(p0): return p0.intValue
             case let .m_trackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_trackScreenEvent__event(p0): return p0.intValue
@@ -1715,6 +1774,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType: return ".trackCourseUnfulfilledPurchaseInitiated(courseID:pacing:screen:flowType:)"
             case .m_trackRestorePurchaseClicked: return ".trackRestorePurchaseClicked()"
             case .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackValuePropViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackSelectionViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackContinueWithFreeTrackClicked(courseID:pacing:lmsPrice:screen:)"
             case .m_trackEvent__event: return ".trackEvent(_:)"
             case .m_trackEvent__eventbiValue_biValue: return ".trackEvent(_:biValue:)"
             case .m_trackScreenEvent__event: return ".trackScreenEvent(_:)"
@@ -1752,6 +1813,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         public static func trackCourseUnfulfilledPurchaseInitiated(courseID: Parameter<String>, pacing: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, flowType: Parameter<UpgradeMode>) -> Verify { return Verify(method: .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(`courseID`, `pacing`, `screen`, `flowType`))}
         public static func trackRestorePurchaseClicked() -> Verify { return Verify(method: .m_trackRestorePurchaseClicked)}
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackEvent__event(`event`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_trackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func trackScreenEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackScreenEvent__event(`event`))}
@@ -1806,6 +1869,12 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         }
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
             return Perform(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
         }
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, perform: @escaping (AnalyticsEvent) -> Void) -> Perform {
             return Perform(method: .m_trackEvent__event(`event`), performs: perform)

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -344,7 +344,7 @@ class ScreenAssembly: Assembly {
         // MARK: CourseScreensView
         container.register(
             CourseContainerViewModel.self
-        ) { r, isActive, courseStart, courseEnd, enrollmentStart, enrollmentEnd, selection, lastVisitedBlockID in
+        ) { r, isActive, courseStart, courseEnd, enrollmentStart, enrollmentEnd, selection, lastVisitedBlockID, showTrackSelection in
             CourseContainerViewModel(
                 interactor: r.resolve(CourseInteractorProtocol.self)!,
                 authInteractor: r.resolve(AuthInteractorProtocol.self)!,
@@ -362,6 +362,7 @@ class ScreenAssembly: Assembly {
                 lastVisitedBlockID: lastVisitedBlockID,
                 coreAnalytics: r.resolve(CoreAnalytics.self)!,
                 selection: selection,
+                showTrackSelection: showTrackSelection,
                 serverConfig: r.resolve(ServerConfigProtocol.self)!
             )
         }
@@ -647,7 +648,24 @@ class ScreenAssembly: Assembly {
                 router: r.resolve(CourseRouter.self)!
             )
         }.inObjectScope(.container)
-        
+
+        container.register(
+            TrackSelectionViewModel.self
+        ) { r, courseID, productName, screen, sku, pacing, lmsPrice, accessExpires in
+            TrackSelectionViewModel(
+                courseID: courseID,
+                productName: productName,
+                screen: screen,
+                sku: sku,
+                pacing: pacing,
+                lmsPrice: lmsPrice,
+                accessExpires: accessExpires,
+                handler: r.resolve(CourseUpgradeHandlerProtocol.self)!,
+                analytics: r.resolve(CoreAnalytics.self)!,
+                router: r.resolve(CourseRouter.self)!
+            )
+        }
+
         // MARK: Upgrade info
         container.register(
             UpgradeInfoViewModel.self

--- a/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
+++ b/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
@@ -1524,7 +1524,45 @@ class AnalyticsManager: AuthorizationAnalytics,
         parameters.setObjectOrNil(lmsPrice, forKey: EventParamKey.lmsPrice)
         logScreenEvent(.courseUpgradeValuePropViewed, parameters: parameters)
     }
-    
+
+    public func trackSelectionViewed(
+        courseID: String,
+        pacing: String,
+        lmsPrice: Double,
+        screen: CourseUpgradeScreen
+    ) {
+        var parameters: [String: Any] = [
+            EventParamKey.category: EventCategory.inAppPurchases,
+            EventParamKey.name: EventBIValue.trackSelectionViewed.rawValue,
+            EventParamKey.screenName: screen.rawValue,
+            EventParamKey.flowType: UpgradeMode.trackSelection.rawValue,
+            EventParamKey.courseID: courseID,
+            EventParamKey.pacing: pacing
+        ]
+        parameters.setObjectOrNil(lmsPrice, forKey: EventParamKey.lmsPrice)
+
+        logScreenEvent(.trackSelectionViewed, parameters: parameters)
+    }
+
+    public func trackContinueWithFreeTrackClicked(
+        courseID: String,
+        pacing: String,
+        lmsPrice: Double,
+        screen: CourseUpgradeScreen
+    ) {
+        var parameters: [String: Any] = [
+            EventParamKey.category: EventCategory.inAppPurchases,
+            EventParamKey.name: EventBIValue.continueWithFreeTrackClicked.rawValue,
+            EventParamKey.screenName: screen.rawValue,
+            EventParamKey.flowType: UpgradeMode.trackSelection.rawValue,
+            EventParamKey.courseID: courseID,
+            EventParamKey.pacing: pacing
+        ]
+        parameters.setObjectOrNil(lmsPrice, forKey: EventParamKey.lmsPrice)
+
+        logEvent(.continueWithFreeTrackClicked, parameters: parameters)
+    }
+
     // MARK: - Notifications
 
     public func notificationScreenEvent(_ event: AnalyticsEvent, biValue: EventBIValue) {

--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
@@ -125,7 +125,8 @@ extension Router: DeepLinkRouter {
                     courseRawImage: courseDetails.courseRawImage,
                     coursewareAccess: nil,
                     showDates: false,
-                    lastVisitedBlockID: nil
+                    lastVisitedBlockID: nil,
+                    showTrackSelection: false
                 )
             } else {
                 showCourseDetais(

--- a/OpenEdX/Managers/PipManager.swift
+++ b/OpenEdX/Managers/PipManager.swift
@@ -192,7 +192,8 @@ public class PipManager: PipManagerProtocol {
             courseRawImage: courseDetails.courseRawImage,
             coursewareAccess: nil,
             showDates: false,
-            lastVisitedBlockID: nil
+            lastVisitedBlockID: nil,
+            showTrackSelection: false
         )
         controller.rootView.viewModel.selection = holder.selectedCourseTab
         return controller

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -21,6 +21,7 @@ import Combine
 import Notifications
 
 // swiftlint:disable file_length type_body_length
+// swiftlint:disable function_parameter_count
 public class Router: AuthorizationRouter,
                      WhatsNewRouter,
                      DiscoveryRouter,
@@ -1094,4 +1095,5 @@ extension Router {
     }
     
 }
+// swiftlint:enable function_parameter_count
 // swiftlint:enable file_length type_body_length

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -390,7 +390,8 @@ public class Router: AuthorizationRouter,
         courseRawImage: String?,
         coursewareAccess: CoursewareAccess?,
         showDates: Bool,
-        lastVisitedBlockID: String?
+        lastVisitedBlockID: String?,
+        showTrackSelection: Bool
     ) {
         let controller = getCourseScreensController(
             courseID: courseID,
@@ -404,7 +405,8 @@ public class Router: AuthorizationRouter,
             courseRawImage: courseRawImage,
             coursewareAccess: coursewareAccess,
             showDates: showDates,
-            lastVisitedBlockID: lastVisitedBlockID
+            lastVisitedBlockID: lastVisitedBlockID,
+            showTrackSelection: showTrackSelection
         )
         navigationController.pushViewController(controller, animated: true)
         
@@ -429,7 +431,8 @@ public class Router: AuthorizationRouter,
         courseRawImage: String?,
         coursewareAccess: CoursewareAccess?,
         showDates: Bool,
-        lastVisitedBlockID: String?
+        lastVisitedBlockID: String?,
+        showTrackSelection: Bool
     ) -> UIHostingController<CourseContainerView> {
         let vm = Container.shared.resolve(
             CourseContainerViewModel.self,
@@ -439,7 +442,8 @@ public class Router: AuthorizationRouter,
             enrollmentStart,
             enrollmentEnd,
             showDates ? CourseTab.dates : CourseTab.course,
-            lastVisitedBlockID
+            lastVisitedBlockID,
+            showTrackSelection
         )!
         
         let datesVm = Container.shared.resolve(
@@ -954,6 +958,35 @@ extension Router {
 
 // MARK: Payments
 extension Router {
+    @MainActor
+    public func showTrackSelection(
+        courseID: String,
+        productName: String,
+        screen: CourseUpgradeScreen,
+        sku: String,
+        pacing: String,
+        lmsPrice: Double,
+        accessExpires: Date
+    ) {
+        let view = TrackSelectionView(
+            viewModel: Container.shared.resolve(
+                TrackSelectionViewModel.self,
+                arguments: courseID, productName, screen, sku, pacing, lmsPrice, accessExpires
+            )!
+        )
+        let controller = UIHostingController(rootView: view)
+        if let sheet = controller.sheetPresentationController,
+           UIDevice.current.userInterfaceIdiom == .pad {
+            sheet.detents = [.large()]
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
+            sheet.prefersGrabberVisible = true
+        } else {
+            controller.modalPresentationStyle = .overFullScreen
+        }
+        navigationController.present(controller, animated: true)
+    }
+
     @MainActor
     public func showUpgradeInfo(
         productName: String,

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -20,8 +20,7 @@ import WhatsNew
 import Combine
 import Notifications
 
-// swiftlint:disable file_length type_body_length
-// swiftlint:disable function_parameter_count
+// swiftlint:disable file_length type_body_length function_parameter_count
 public class Router: AuthorizationRouter,
                      WhatsNewRouter,
                      DiscoveryRouter,
@@ -1095,5 +1094,4 @@ extension Router {
     }
     
 }
-// swiftlint:enable function_parameter_count
-// swiftlint:enable file_length type_body_length
+// swiftlint:enable file_length type_body_length function_parameter_count

--- a/Profile/ProfileTests/ProfileMock.generated.swift
+++ b/Profile/ProfileTests/ProfileMock.generated.swift
@@ -612,6 +612,13 @@ open class BaseRouterMock: BaseRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -699,6 +706,7 @@ open class BaseRouterMock: BaseRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -810,6 +818,17 @@ open class BaseRouterMock: BaseRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -873,6 +892,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -904,6 +924,7 @@ open class BaseRouterMock: BaseRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -949,6 +970,8 @@ open class BaseRouterMock: BaseRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -1024,6 +1047,10 @@ open class BaseRouterMock: BaseRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {
@@ -1469,6 +1496,18 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
     }
 
+    open func trackSelectionViewed(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
+    open func trackContinueWithFreeTrackClicked(courseID: String, pacing: String, lmsPrice: Double, screen: CourseUpgradeScreen) {
+        addInvocation(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`)))
+		let perform = methodPerformValue(.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>.value(`courseID`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<CourseUpgradeScreen>.value(`screen`))) as? (String, String, Double, CourseUpgradeScreen) -> Void
+		perform?(`courseID`, `pacing`, `lmsPrice`, `screen`)
+    }
+
     open func trackEvent(_ event: AnalyticsEvent) {
         addInvocation(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`)))
 		let perform = methodPerformValue(.m_trackEvent__event(Parameter<AnalyticsEvent>.value(`event`))) as? (AnalyticsEvent) -> Void
@@ -1510,6 +1549,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         case m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeMode>)
         case m_trackRestorePurchaseClicked
         case m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
+        case m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<CourseUpgradeScreen>)
         case m_trackEvent__event(Parameter<AnalyticsEvent>)
         case m_trackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_trackScreenEvent__event(Parameter<AnalyticsEvent>)
@@ -1650,6 +1691,22 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
+            case (.m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let lhsCourseid, let lhsPacing, let lhsLmsprice, let lhsScreen), .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(let rhsCourseid, let rhsPacing, let rhsLmsprice, let rhsScreen)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_trackEvent__event(let lhsEvent), .m_trackEvent__event(let rhsEvent)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
@@ -1692,6 +1749,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case let .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case .m_trackRestorePurchaseClicked: return 0
             case let .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
             case let .m_trackEvent__event(p0): return p0.intValue
             case let .m_trackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_trackScreenEvent__event(p0): return p0.intValue
@@ -1715,6 +1774,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
             case .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType: return ".trackCourseUnfulfilledPurchaseInitiated(courseID:pacing:screen:flowType:)"
             case .m_trackRestorePurchaseClicked: return ".trackRestorePurchaseClicked()"
             case .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackValuePropViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackSelectionViewed(courseID:pacing:lmsPrice:screen:)"
+            case .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen: return ".trackContinueWithFreeTrackClicked(courseID:pacing:lmsPrice:screen:)"
             case .m_trackEvent__event: return ".trackEvent(_:)"
             case .m_trackEvent__eventbiValue_biValue: return ".trackEvent(_:biValue:)"
             case .m_trackScreenEvent__event: return ".trackScreenEvent(_:)"
@@ -1752,6 +1813,8 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         public static func trackCourseUnfulfilledPurchaseInitiated(courseID: Parameter<String>, pacing: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, flowType: Parameter<UpgradeMode>) -> Verify { return Verify(method: .m_trackCourseUnfulfilledPurchaseInitiated__courseID_courseIDpacing_pacingscreen_screenflowType_flowType(`courseID`, `pacing`, `screen`, `flowType`))}
         public static func trackRestorePurchaseClicked() -> Verify { return Verify(method: .m_trackRestorePurchaseClicked)}
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackEvent__event(`event`))}
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_trackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func trackScreenEvent(_ event: Parameter<AnalyticsEvent>) -> Verify { return Verify(method: .m_trackScreenEvent__event(`event`))}
@@ -1806,6 +1869,12 @@ open class CoreAnalyticsMock: CoreAnalytics, Mock {
         }
         public static func trackValuePropViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
             return Perform(method: .m_trackValuePropViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackSelectionViewed(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackSelectionViewed__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
+        }
+        public static func trackContinueWithFreeTrackClicked(courseID: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, screen: Parameter<CourseUpgradeScreen>, perform: @escaping (String, String, Double, CourseUpgradeScreen) -> Void) -> Perform {
+            return Perform(method: .m_trackContinueWithFreeTrackClicked__courseID_courseIDpacing_pacinglmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `lmsPrice`, `screen`), performs: perform)
         }
         public static func trackEvent(_ event: Parameter<AnalyticsEvent>, perform: @escaping (AnalyticsEvent) -> Void) -> Perform {
             return Perform(method: .m_trackEvent__event(`event`), performs: perform)
@@ -4470,6 +4539,13 @@ open class ProfileRouterMock: ProfileRouter, Mock {
     }
 
     @MainActor
+	open func showTrackSelection(courseID: String, productName: String, screen: CourseUpgradeScreen, sku: String, pacing: String, lmsPrice: Double, accessExpires: Date) {
+        addInvocation(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`)))
+		let perform = methodPerformValue(.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>.value(`courseID`), Parameter<String>.value(`productName`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`sku`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`), Parameter<Date>.value(`accessExpires`))) as? (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void
+		perform?(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`)
+    }
+
+    @MainActor
 	open func showUpgradeInfo(productName: String, message: String, sku: String, courseID: String, screen: CourseUpgradeScreen, pacing: String, lmsPrice: Double) {
         addInvocation(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`)))
 		let perform = methodPerformValue(.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>.value(`productName`), Parameter<String>.value(`message`), Parameter<String>.value(`sku`), Parameter<String>.value(`courseID`), Parameter<CourseUpgradeScreen>.value(`screen`), Parameter<String>.value(`pacing`), Parameter<Double>.value(`lmsPrice`))) as? (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void
@@ -4568,6 +4644,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         case m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(Parameter<UIModalTransitionStyle>, Parameter<any View>, Parameter<(() -> Void)?>)
         case m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(Parameter<UIModalTransitionStyle>, Parameter<Bool>, Parameter<() -> any View>)
         case m_presentNativeAlert__title_titlemessage_messageactions_actions(Parameter<String?>, Parameter<String?>, Parameter<[UIAlertAction]>)
+        case m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<Date>)
         case m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(Parameter<String>, Parameter<String>, Parameter<String>, Parameter<String>, Parameter<CourseUpgradeScreen>, Parameter<String>, Parameter<Double>)
         case m_hideUpgradeInfo__animated_animated(Parameter<Bool>)
         case m_showUpgradeLoaderView__animated_animated(Parameter<Bool>)
@@ -4714,6 +4791,17 @@ open class ProfileRouterMock: ProfileRouter, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsActions, rhs: rhsActions, with: matcher), lhsActions, rhsActions, "actions"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let lhsCourseid, let lhsProductname, let lhsScreen, let lhsSku, let lhsPacing, let lhsLmsprice, let lhsAccessexpires), .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(let rhsCourseid, let rhsProductname, let rhsScreen, let rhsSku, let rhsPacing, let rhsLmsprice, let rhsAccessexpires)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsCourseid, rhs: rhsCourseid, with: matcher), lhsCourseid, rhsCourseid, "courseID"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsScreen, rhs: rhsScreen, with: matcher), lhsScreen, rhsScreen, "screen"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPacing, rhs: rhsPacing, with: matcher), lhsPacing, rhsPacing, "pacing"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsLmsprice, rhs: rhsLmsprice, with: matcher), lhsLmsprice, rhsLmsprice, "lmsPrice"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsAccessexpires, rhs: rhsAccessexpires, with: matcher), lhsAccessexpires, rhsAccessexpires, "accessExpires"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let lhsProductname, let lhsMessage, let lhsSku, let lhsCourseid, let lhsScreen, let lhsPacing, let lhsLmsprice), .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(let rhsProductname, let rhsMessage, let rhsSku, let rhsCourseid, let rhsScreen, let rhsPacing, let rhsLmsprice)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsProductname, rhs: rhsProductname, with: matcher), lhsProductname, rhsProductname, "productName"))
@@ -4788,6 +4876,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
             case let .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_presentNativeAlert__title_titlemessage_messageactions_actions(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_hideUpgradeInfo__animated_animated(p0): return p0.intValue
             case let .m_showUpgradeLoaderView__animated_animated(p0): return p0.intValue
@@ -4830,6 +4919,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
             case .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion: return ".presentView(transitionStyle:view:completion:)"
             case .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content: return ".presentView(transitionStyle:animated:content:)"
             case .m_presentNativeAlert__title_titlemessage_messageactions_actions: return ".presentNativeAlert(title:message:actions:)"
+            case .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires: return ".showTrackSelection(courseID:productName:screen:sku:pacing:lmsPrice:accessExpires:)"
             case .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice: return ".showUpgradeInfo(productName:message:sku:courseID:screen:pacing:lmsPrice:)"
             case .m_hideUpgradeInfo__animated_animated: return ".hideUpgradeInfo(animated:)"
             case .m_showUpgradeLoaderView__animated_animated: return ".showUpgradeLoaderView(animated:)"
@@ -4886,6 +4976,8 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, view: Parameter<any View>, completion: Parameter<(() -> Void)?>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleview_viewcompletion_completion(`transitionStyle`, `view`, `completion`))}
         public static func presentView(transitionStyle: Parameter<UIModalTransitionStyle>, animated: Parameter<Bool>, content: Parameter<() -> any View>) -> Verify { return Verify(method: .m_presentView__transitionStyle_transitionStyleanimated_animatedcontent_content(`transitionStyle`, `animated`, `content`))}
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>) -> Verify { return Verify(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`))}
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>) -> Verify { return Verify(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`))}
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>) -> Verify { return Verify(method: .m_showUpgradeInfo__productName_productNamemessage_messagesku_skucourseID_courseIDscreen_screenpacing_pacinglmsPrice_lmsPrice(`productName`, `message`, `sku`, `courseID`, `screen`, `pacing`, `lmsPrice`))}
         @MainActor
@@ -4994,6 +5086,10 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         }
         public static func presentNativeAlert(title: Parameter<String?>, message: Parameter<String?>, actions: Parameter<[UIAlertAction]>, perform: @escaping (String?, String?, [UIAlertAction]) -> Void) -> Perform {
             return Perform(method: .m_presentNativeAlert__title_titlemessage_messageactions_actions(`title`, `message`, `actions`), performs: perform)
+        }
+        @MainActor
+		public static func showTrackSelection(courseID: Parameter<String>, productName: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, sku: Parameter<String>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, accessExpires: Parameter<Date>, perform: @escaping (String, String, CourseUpgradeScreen, String, String, Double, Date) -> Void) -> Perform {
+            return Perform(method: .m_showTrackSelection__courseID_courseIDproductName_productNamescreen_screensku_skupacing_pacinglmsPrice_lmsPriceaccessExpires_accessExpires(`courseID`, `productName`, `screen`, `sku`, `pacing`, `lmsPrice`, `accessExpires`), performs: perform)
         }
         @MainActor
 		public static func showUpgradeInfo(productName: Parameter<String>, message: Parameter<String>, sku: Parameter<String>, courseID: Parameter<String>, screen: Parameter<CourseUpgradeScreen>, pacing: Parameter<String>, lmsPrice: Parameter<Double>, perform: @escaping (String, String, String, String, CourseUpgradeScreen, String, Double) -> Void) -> Perform {


### PR DESCRIPTION
[LEARNER-10087](https://2u-internal.atlassian.net/browse/LEARNER-10087): Track selection on enrollment

### Description
This PR introduces a native track selection screen shown after learners enroll in a course from the Discover or Programs modules. This mirrors the web experience and is designed to encourage learners to upgrade early in their journey.

### Preview
**iPhone**
| Orientation | Light Theme | Dark Theme |
| - | - | - |
| Portrait | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 18 23 59](https://github.com/user-attachments/assets/a2a08348-cf09-42b7-89bf-f49ecbcfa471) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 18 24 05](https://github.com/user-attachments/assets/633492d0-b355-41d2-8926-1e8de8876c7b) |
| Landscape | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 18 24 16](https://github.com/user-attachments/assets/d1e1cf26-8334-4fcd-bb3d-9340a3154d1f) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 18 24 22](https://github.com/user-attachments/assets/2375c26e-8dcb-448a-8b0a-9fccb85545b4) |

**iPad**
| Orientation | Light Theme | Dark Theme |
| - | - | - |
| Portrait | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-05-12 at 18 28 22](https://github.com/user-attachments/assets/fb585f93-c8af-44af-936d-702a263169bd) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-05-12 at 18 28 31](https://github.com/user-attachments/assets/22305a95-4b29-4913-a38d-c7318202d060) |
| Landscape | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-05-12 at 18 28 41](https://github.com/user-attachments/assets/4ca8b6bf-5145-4383-90be-c87fe0f2569e) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-05-12 at 18 28 49](https://github.com/user-attachments/assets/e2845fe1-6360-4d03-8490-4891b010cec8) |

**Demo**
<video src="https://github.com/user-attachments/assets/f3339180-9e8c-450e-96bf-7a6906bcbb19" />