### PR TITLE
feat: add option to change app appearance settings

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -193,6 +193,9 @@
 		94AE32362D8B329D00FA048D /* NotificationBellButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AE32352D8B329D00FA048D /* NotificationBellButton.swift */; };
 		94D1FC482DA6AF44000A904F /* EDXFeatureManagement in Frameworks */ = {isa = PBXBuildFile; productRef = 94D1FC472DA6AF44000A904F /* EDXFeatureManagement */; };
 		94D1FC4D2DA7F3A6000A904F /* OptimizelyConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D1FC4C2DA7F39F000A904F /* OptimizelyConfig.swift */; };
+		94E5D5962DE4959900DE43ED /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E5D5952DE4959600DE43ED /* AppTheme.swift */; };
+		94E5D5982DE495BD00DE43ED /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E5D5972DE495BA00DE43ED /* ThemeManager.swift */; };
+		94E5D59A2DE4990700DE43ED /* ThemeManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E5D5992DE4990100DE43ED /* ThemeManagerProtocol.swift */; };
 		973CCD7B2D3660D100949756 /* HTML2TextParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973CCD792D3660D100949756 /* HTML2TextParser.swift */; };
 		973CCD7C2D3660D100949756 /* AttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973CCD782D3660D100949756 /* AttributedText.swift */; };
 		9784D47E2BF7762800AFEFFF /* FullScreenErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9784D47D2BF7762800AFEFFF /* FullScreenErrorView.swift */; };
@@ -440,6 +443,9 @@
 		9499F1252D41375B00558D59 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		94AE32352D8B329D00FA048D /* NotificationBellButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBellButton.swift; sourceTree = "<group>"; };
 		94D1FC4C2DA7F39F000A904F /* OptimizelyConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyConfig.swift; sourceTree = "<group>"; };
+		94E5D5952DE4959600DE43ED /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
+		94E5D5972DE495BA00DE43ED /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
+		94E5D5992DE4990100DE43ED /* ThemeManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManagerProtocol.swift; sourceTree = "<group>"; };
 		973CCD782D3660D100949756 /* AttributedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedText.swift; sourceTree = "<group>"; };
 		973CCD792D3660D100949756 /* HTML2TextParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTML2TextParser.swift; sourceTree = "<group>"; };
 		9784D47D2BF7762800AFEFFF /* FullScreenErrorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullScreenErrorView.swift; sourceTree = "<group>"; };
@@ -731,6 +737,7 @@
 				14DE13D82BDF7E4E0059168F /* ServerConfig */,
 				DBF6F2422B014AF30098414B /* Config */,
 				CFC84955299FAC4D0055E497 /* Combine */,
+				94E5D5942DE4958E00DE43ED /* Theme */,
 				9499F1252D41375B00558D59 /* AppEnvironment.swift */,
 				0770DE1828D0847D006D8A5D /* BaseRouter.swift */,
 				0231CDBD2922422D00032416 /* CSSInjector.swift */,
@@ -999,6 +1006,16 @@
 				942A98542D4BD91700DD8BBC /* PaginationTask.swift */,
 			);
 			path = Pagination;
+			sourceTree = "<group>";
+		};
+		94E5D5942DE4958E00DE43ED /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				94E5D5952DE4959600DE43ED /* AppTheme.swift */,
+				94E5D5972DE495BA00DE43ED /* ThemeManager.swift */,
+				94E5D5992DE4990100DE43ED /* ThemeManagerProtocol.swift */,
+			);
+			path = Theme;
 			sourceTree = "<group>";
 		};
 		973CCD7A2D3660D100949756 /* AttributedText */ = {
@@ -1387,6 +1404,7 @@
 				028F9F37293A44C700DE65D0 /* Data_ResetPassword.swift in Sources */,
 				022C64E429AE0191000F532B /* TextWithUrls.swift in Sources */,
 				0283348028D4DCD200C828FC /* ViewExtension.swift in Sources */,
+				94E5D5962DE4959900DE43ED /* AppTheme.swift in Sources */,
 				BA8FA66A2AD59B5500EA029A /* GoogleAuthProvider.swift in Sources */,
 				02A4833529B8A73400D33F33 /* CorePersistenceProtocol.swift in Sources */,
 				06EA8A482BFDFEFD005DFB90 /* CourseUpgradeHandlerProtocol.swift in Sources */,
@@ -1453,6 +1471,7 @@
 				062C69AC2C198323002BD311 /* UpgradeInfoView.swift in Sources */,
 				064987952B4D69FF0071642A /* SurveyCssInjection.swift in Sources */,
 				949094992DC8E44C00A341D4 /* TrackCardInfo.swift in Sources */,
+				94E5D59A2DE4990700DE43ED /* ThemeManagerProtocol.swift in Sources */,
 				02E224DB2BB76B3E00EF1ADB /* DynamicOffsetView.swift in Sources */,
 				0259104A29C4A5B6004B5A55 /* UserSettings.swift in Sources */,
 				021D925028DC89D100ACC565 /* UserProfile.swift in Sources */,
@@ -1476,6 +1495,7 @@
 				02AFCC182AEFDB24000360F0 /* ThirdPartyMailClient.swift in Sources */,
 				0233D5712AF13EC800BAC8BD /* SelectMailClientView.swift in Sources */,
 				14A8325B2BD7615C00E5654D /* CourseUpgradeRepository.swift in Sources */,
+				94E5D5982DE495BD00DE43ED /* ThemeManager.swift in Sources */,
 				BAFB99842B0E282E007D09F9 /* MicrosoftConfig.swift in Sources */,
 				02B2B594295C5C7A00914876 /* Thread.swift in Sources */,
 				E0D5861C2B2FF85B009B4BA7 /* RawStringExtactable.swift in Sources */,

--- a/Core/Core/Analytics/CoreAnalytics.swift
+++ b/Core/Core/Analytics/CoreAnalytics.swift
@@ -300,6 +300,8 @@ public enum AnalyticsEvent: String {
     case videoDownloadQualityChanged = "Video:Download Quality Changed"
     case profileVideoSettingsClicked = "Profile:Video Setting Clicked"
     case profilePushSettingsClicked = "Profile:Push Notifications Setting Clicked"
+    case profileAppearanceSettingClicked = "Profile:Appearance Setting Clicked"
+    case profileAppThemeChanged = "Profile:App Theme Changed"
     case privacyPolicyClicked = "Profile:Privacy Policy Clicked"
     case cookiePolicyClicked = "Profile:Cookie Policy Clicked"
     case emailSupportClicked = "Profile:Contact Support Clicked"
@@ -441,6 +443,8 @@ public enum EventBIValue: String {
     case profileEditDoneClicked = "edx.bi.app.profile.edit_done.clicked"
     case profileVideoSettingsClicked = "edx.bi.app.profile.video_setting.clicked"
     case profilePushSettingsClicked = "edx.bi.app.profile.push_notifications_setting.clicked"
+    case profileAppearanceSettingClicked = "edx.bi.app.profile.appearance_setting.clicked"
+    case profileAppThemeChanged = "edx.bi.app.profile.app_theme.changed"
     case emailSupportClicked = "edx.bi.app.profile.email_support.clicked"
     case faqClicked = "edx.bi.app.profile.faq.clicked"
     case tosClicked = "edx.bi.app.profile.terms_of_use.clicked"
@@ -618,6 +622,8 @@ public struct EventParamKey {
     public static let unreadNotifications = "unread_notifications"
     public static let dialogFrequency = "dialog_frequency"
     public static let source = "source"
+    public static let newMode = "new_mode"
+    public static let previousMode = "previous_mode"
 }
 
 public struct EventCategory {

--- a/Core/Core/Configuration/Theme/AppTheme.swift
+++ b/Core/Core/Configuration/Theme/AppTheme.swift
@@ -1,0 +1,23 @@
+//
+//  AppTheme.swift
+//  Core
+//
+//  Created by Muhammad Tayyab Akram on 5/26/25.
+//
+
+public enum AppTheme: String {
+    case system
+    case light
+    case dark
+
+    public var analyticsValue: String {
+        switch self {
+        case .system:
+            return "auto"
+        case .light:
+            return "light"
+        case .dark:
+            return "dark"
+        }
+    }
+}

--- a/Core/Core/Configuration/Theme/ThemeManager.swift
+++ b/Core/Core/Configuration/Theme/ThemeManager.swift
@@ -1,0 +1,47 @@
+//
+//  ThemeManager.swift
+//  Core
+//
+//  Created by Muhammad Tayyab Akram on 5/26/25.
+//
+
+import UIKit
+
+public final class ThemeManager: ThemeManagerProtocol {
+    private var storage: CoreStorage
+
+    public init(storage: CoreStorage) {
+        self.storage = storage
+    }
+
+    public var currentTheme: AppTheme {
+        get {
+            return storage.selectedTheme ?? .system
+        }
+        set {
+            storage.selectedTheme = newValue
+            applyTheme(newValue)
+        }
+    }
+
+    public func applySavedTheme() {
+        applyTheme(currentTheme)
+    }
+
+    private func applyTheme(_ theme: AppTheme) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            return
+        }
+
+        for window in windowScene.windows {
+            switch theme {
+            case .system:
+                window.overrideUserInterfaceStyle = .unspecified
+            case .light:
+                window.overrideUserInterfaceStyle = .light
+            case .dark:
+                window.overrideUserInterfaceStyle = .dark
+            }
+        }
+    }
+}

--- a/Core/Core/Configuration/Theme/ThemeManagerProtocol.swift
+++ b/Core/Core/Configuration/Theme/ThemeManagerProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  ThemeManagerProtocol.swift
+//  Core
+//
+//  Created by Muhammad Tayyab Akram on 5/26/25.
+//
+
+import Foundation
+
+public protocol ThemeManagerProtocol {
+    var currentTheme: AppTheme { get set }
+
+    func applySavedTheme()
+}
+
+// Mark - For testing and SwiftUI preview
+#if DEBUG
+public final class ThemeManagerMock: ThemeManagerProtocol {
+    public var currentTheme: AppTheme = .system
+
+    public init() {}
+    public func applySavedTheme() {}
+}
+#endif

--- a/Core/Core/Data/CoreStorage.swift
+++ b/Core/Core/Data/CoreStorage.swift
@@ -21,6 +21,7 @@ public protocol CoreStorage {
     var resetAppSupportDirectoryUserData: Bool? {get set}
     var lastUsedSocialAuth: String? {get set}
     var discussionNotificationsSettingStatus: Bool? {get set}
+    var selectedTheme: AppTheme? {get set}
     func clear()
 }
 
@@ -39,6 +40,7 @@ public class CoreStorageMock: CoreStorage {
     public var resetAppSupportDirectoryUserData: Bool?
     public var lastUsedSocialAuth: String?
     public var discussionNotificationsSettingStatus: Bool?
+    public var selectedTheme: AppTheme?
     public func clear() {}
     
     public init() {}

--- a/OpenEdX/AppDelegate.swift
+++ b/OpenEdX/AppDelegate.swift
@@ -77,7 +77,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = RouteController()
         window?.makeKeyAndVisible()
         window?.tintColor = Theme.UIColors.accentColor
-        
+
+        applyTheme()
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(didUserAuthorize),
@@ -150,7 +152,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             container: Container.shared
         )
     }
-    
+
+    private func applyTheme() {
+        guard let themeManager = Container.shared.resolve(ThemeManagerProtocol.self) else {
+            return
+        }
+
+        themeManager.applySavedTheme()
+    }
+
     @objc private func didUserAuthorize() {
         Container.shared.resolve(PushNotificationsManager.self)?.synchronizeToken()
     }

--- a/OpenEdX/DI/AppAssembly.swift
+++ b/OpenEdX/DI/AppAssembly.swift
@@ -239,6 +239,12 @@ class AppAssembly: Assembly {
             )
         }.inObjectScope(.container)
 
+        container.register(ThemeManagerProtocol.self) { r in
+            ThemeManager(
+                storage: r.resolve(CoreStorage.self)!
+            )
+        }.inObjectScope(.container)
+
         // Initialize Feature Manager...
         container.resolve(FeatureManagerProtocol.self)
     }

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -285,7 +285,15 @@ class ScreenAssembly: Assembly {
                 storage: r.resolve(CoreStorage.self)!
             )
         }
-        
+
+        container.register(AppearanceSettingsViewModel.self) { r in
+            AppearanceSettingsViewModel(
+                themeManager: r.resolve(ThemeManagerProtocol.self)!,
+                router: r.resolve(ProfileRouter.self)!,
+                analytics: r.resolve(ProfileAnalytics.self)!
+            )
+        }
+
         container.register(DatesAndCalendarViewModel.self) { r in
             DatesAndCalendarViewModel(
                 router: r.resolve(ProfileRouter.self)!

--- a/OpenEdX/Data/AppStorage.swift
+++ b/OpenEdX/Data/AppStorage.swift
@@ -285,7 +285,23 @@ public class AppStorage: CoreStorage, ProfileStorage, WhatsNewStorage, CourseSto
             }
         }
     }
-    
+
+    public var selectedTheme: AppTheme? {
+        get {
+            guard let rawValue = userDefaults.string(forKey: KEY_SELECTED_THEME) else {
+                return nil
+            }
+            return AppTheme(rawValue: rawValue)
+        }
+        set(newValue) {
+            if let newValue {
+                userDefaults.set(newValue.rawValue, forKey: KEY_SELECTED_THEME)
+            } else {
+                userDefaults.removeObject(forKey: KEY_SELECTED_THEME)
+            }
+        }
+    }
+
     public var notificationsPrimerDismissalCount: Int {
         get {
             return userDefaults.integer(forKey: KEY_NOTIFICATIONS_PRIMER_DISMISSAL_COUNT)
@@ -349,6 +365,7 @@ public class AppStorage: CoreStorage, ProfileStorage, WhatsNewStorage, CourseSto
     private let KEY_RESET_APP_SUPPORT_DIRECTORY_USER_DATA = "resetAppSupportDirectoryUserData"
     private let KEY_LAST_USED_SOCIAL_AUTH = "lastUsedSocialAuth"
     private let KEY_DISCUSSION_NOTIFICATIONS_SETTING_STATUS = "discussionNotificationsSettingStatus"
+    private let KEY_SELECTED_THEME = "selectedTheme"
     private let KEY_NOTIFICATIONS_PRIMER_DISMISSAL_COUNT = "notificationsPrimerDismissalCount"
     private let KEY_NOTIFICATIONS_PRIMER_LAST_SHOWN_DATE = "notificationsPrimerLastShownDate"
 

--- a/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
+++ b/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
@@ -493,7 +493,19 @@ class AnalyticsManager: AuthorizationAnalytics,
             ]
         )
     }
-    
+
+    public func profileAppThemeChanged(newMode: String, previousMode: String) {
+        trackEvent(
+            .profileAppThemeChanged,
+            biValue: .profileAppThemeChanged,
+            parameters: [
+                EventParamKey.category: EventCategory.profile,
+                EventParamKey.newMode: newMode,
+                EventParamKey.previousMode: previousMode
+            ]
+        )
+    }
+
     public func videoQualityChanged(
         _ event: AnalyticsEvent,
         bivalue: EventBIValue,

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -813,7 +813,14 @@ public class Router: AuthorizationRouter,
         let controller = UIHostingController(rootView: view)
         navigationController.pushViewController(controller, animated: true)
     }
-    
+
+    public func showAppearanceSettings() {
+        let viewModel = Container.shared.resolve(AppearanceSettingsViewModel.self)!
+        let view = AppearanceSettingsView(viewModel: viewModel)
+        let controller = UIHostingController(rootView: view)
+        navigationController.pushViewController(controller, animated: true)
+    }
+
     public func showDatesAndCalendar() {
         let viewModel = Container.shared.resolve(DatesAndCalendarViewModel.self)!
         let view = DatesAndCalendarView(viewModel: viewModel)

--- a/Profile/Profile.xcodeproj/project.pbxproj
+++ b/Profile/Profile.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		0796C8C929B7905300444B05 /* ProfileBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0796C8C829B7905300444B05 /* ProfileBottomSheet.swift */; };
 		25B36FF48C1307888A3890DA /* Pods_App_Profile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEA369C38362C1A91A012F70 /* Pods_App_Profile.framework */; };
 		94D1FC4B2DA6BAA0000A904F /* EDXFeatureManagement in Frameworks */ = {isa = PBXBuildFile; productRef = 94D1FC4A2DA6BAA0000A904F /* EDXFeatureManagement */; };
+		94E5D58D2DE08B4C00DE43ED /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E5D58C2DE08B4C00DE43ED /* AppearanceSettingsView.swift */; };
+		94E5D58F2DE0A12700DE43ED /* AppearanceSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E5D58E2DE0A11F00DE43ED /* AppearanceSettingsViewModel.swift */; };
 		BAD9CA3F2B29BF5C00DE790A /* ProfileSupportInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD9CA3E2B29BF5C00DE790A /* ProfileSupportInfoView.swift */; };
 		E8264C634DD8AD314ECE8905 /* Pods_App_Profile_ProfileTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C85ADF87135E03275A980E07 /* Pods_App_Profile_ProfileTests.framework */; };
 /* End PBXBuildFile section */
@@ -119,6 +121,8 @@
 		7B80961BB9886B28B90B9ECB /* Pods-App-Profile.releasestage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Profile.releasestage.xcconfig"; path = "Target Support Files/Pods-App-Profile/Pods-App-Profile.releasestage.xcconfig"; sourceTree = "<group>"; };
 		7F6936DF5D5491AE5B6403BC /* Pods-App-Profile-ProfileTests.debugdev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Profile-ProfileTests.debugdev.xcconfig"; path = "Target Support Files/Pods-App-Profile-ProfileTests/Pods-App-Profile-ProfileTests.debugdev.xcconfig"; sourceTree = "<group>"; };
 		8C5B79329D30C10E32838360 /* Pods-App-Profile-ProfileTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Profile-ProfileTests.release.xcconfig"; path = "Target Support Files/Pods-App-Profile-ProfileTests/Pods-App-Profile-ProfileTests.release.xcconfig"; sourceTree = "<group>"; };
+		94E5D58C2DE08B4C00DE43ED /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
+		94E5D58E2DE0A11F00DE43ED /* AppearanceSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsViewModel.swift; sourceTree = "<group>"; };
 		99E3D23305C745FE0FF57A62 /* Pods-App-Profile.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Profile.release.xcconfig"; path = "Target Support Files/Pods-App-Profile/Pods-App-Profile.release.xcconfig"; sourceTree = "<group>"; };
 		9AC2F1A5AE5AC7F0CFCB9FE3 /* Pods-App-Profile-ProfileTests.releasedev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Profile-ProfileTests.releasedev.xcconfig"; path = "Target Support Files/Pods-App-Profile-ProfileTests/Pods-App-Profile-ProfileTests.releasedev.xcconfig"; sourceTree = "<group>"; };
 		9D125F82E0EAC4B6C0CE280F /* Pods-App-Profile-ProfileTests.releaseprod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Profile-ProfileTests.releaseprod.xcconfig"; path = "Target Support Files/Pods-App-Profile-ProfileTests/Pods-App-Profile-ProfileTests.releaseprod.xcconfig"; sourceTree = "<group>"; };
@@ -287,6 +291,8 @@
 				020CBD8C2BC53E1B003D6B4E /* VideoSettingsView.swift */,
 				0259104729C3A5F0004B5A55 /* VideoQualityView.swift */,
 				0259104529C39CCF004B5A55 /* SettingsViewModel.swift */,
+				94E5D58C2DE08B4C00DE43ED /* AppearanceSettingsView.swift */,
+				94E5D58E2DE0A11F00DE43ED /* AppearanceSettingsViewModel.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -658,12 +664,14 @@
 				021D925228DC918D00ACC565 /* ProfileViewModel.swift in Sources */,
 				0248F9B128DDB09D0041327E /* Strings.swift in Sources */,
 				020306CA2932B14D000949EA /* EditProfileViewModel.swift in Sources */,
+				94E5D58D2DE08B4C00DE43ED /* AppearanceSettingsView.swift in Sources */,
 				0259104829C3A5F0004B5A55 /* VideoQualityView.swift in Sources */,
 				0288C4EA2BC6AE2D009158B9 /* ManageAccountView.swift in Sources */,
 				022301E62BF4B7A20028A287 /* AssignmentStatusView.swift in Sources */,
 				021D924628DC634300ACC565 /* ProfileView.swift in Sources */,
 				02F3BFE7292539850051930C /* ProfileRouter.swift in Sources */,
 				02D0FD0B2AD6984D0020D752 /* UserProfileViewModel.swift in Sources */,
+				94E5D58F2DE0A12700DE43ED /* AppearanceSettingsViewModel.swift in Sources */,
 				020CBD8D2BC53E1B003D6B4E /* VideoSettingsView.swift in Sources */,
 				02F175352A4DAD030019CD70 /* ProfileAnalytics.swift in Sources */,
 				02F81DDF2BF4D83E002D3604 /* CalendarDialogView.swift in Sources */,

--- a/Profile/Profile/Presentation/ProfileAnalytics.swift
+++ b/Profile/Profile/Presentation/ProfileAnalytics.swift
@@ -25,6 +25,7 @@ public protocol ProfileAnalytics {
     func profileWifiToggle(action: String)
     func profileUserDeleteAccountClicked()
     func profileDeleteAccountSuccess(success: Bool)
+    func profileAppThemeChanged(newMode: String, previousMode: String)
     func profileTrackEvent(_ event: AnalyticsEvent, biValue: EventBIValue)
     func profileScreenEvent(_ event: AnalyticsEvent, biValue: EventBIValue)
 }
@@ -46,6 +47,7 @@ class ProfileAnalyticsMock: ProfileAnalytics {
     public func profileWifiToggle(action: String) {}
     public func profileUserDeleteAccountClicked() {}
     public func profileDeleteAccountSuccess(success: Bool) {}
+    public func profileAppThemeChanged(newMode: String, previousMode: String) {}
     public func profileTrackEvent(_ event: AnalyticsEvent, biValue: EventBIValue) {}
     public func profileScreenEvent(_ event: AnalyticsEvent, biValue: EventBIValue) {}
 }

--- a/Profile/Profile/Presentation/ProfileRouter.swift
+++ b/Profile/Profile/Presentation/ProfileRouter.swift
@@ -23,7 +23,9 @@ public protocol ProfileRouter: BaseRouter {
     func showVideoSettings()
     
     func showPushSettings()
-    
+
+    func showAppearanceSettings()
+
     func showManageAccount()
     
     func showDatesAndCalendar()
@@ -61,7 +63,9 @@ public class ProfileRouterMock: BaseRouterMock, ProfileRouter {
     public func showVideoSettings() {}
     
     public func showPushSettings() {}
-    
+
+    public func showAppearanceSettings() {}
+
     public func showDatesAndCalendar() {}
     
     public func showSyncCalendarOptions() {}

--- a/Profile/Profile/Presentation/Settings/AppearanceSettingsView.swift
+++ b/Profile/Profile/Presentation/Settings/AppearanceSettingsView.swift
@@ -12,6 +12,7 @@ import Theme
 public struct AppearanceSettingsView: View {
     @ObservedObject
     private var viewModel: AppearanceSettingsViewModel
+    @Environment(\.isHorizontal) private var isHorizontal
 
     public init(viewModel: AppearanceSettingsViewModel) {
         self.viewModel = viewModel
@@ -21,50 +22,47 @@ public struct AppearanceSettingsView: View {
         GeometryReader { proxy in
             ZStack(alignment: .top) {
                 VStack {
-                    topBar
+                    ThemeAssets.headerBackground.swiftUIImage
+                        .resizable()
+                        .edgesIgnoringSafeArea(.top)
+                }
+                .frame(maxWidth: .infinity, maxHeight: 200)
+
+                VStack(alignment: .center) {
+                    ZStack {
+                        HStack {
+                            Text(ProfileLocalization.Settings.appearanceSettingsTitle)
+                                .titleSettings(color: Theme.Colors.loginNavigationText)
+                                .accessibilityIdentifier("appearance_text")
+                        }
+                        VStack {
+                            BackNavigationButton(
+                                color: Theme.Colors.loginNavigationText,
+                                action: {
+                                    viewModel.backButtonPressed()
+                                }
+                            )
+                            .backViewStyle()
+                            .padding(.leading, isHorizontal ? 48 : 0)
+                            .accessibilityIdentifier("back_button")
+
+                        }
+                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)
+                    }
+
                     content(geometry: proxy)
+                        .roundedBackground(Theme.Colors.background)
                 }
             }
-            .hideNavigationBar(true)
-            .navigationBarBackButtonHidden(true)
-            .navigationTitle(ProfileLocalization.Settings.appearanceSettingsTitle)
         }
+        .hideNavigationBar(true)
+        .navigationBarBackButtonHidden(true)
+        .navigationTitle(ProfileLocalization.Settings.appearanceSettingsTitle)
+        .ignoresSafeArea(.all, edges: .horizontal)
         .background(
             Theme.Colors.background
                 .ignoresSafeArea()
         )
-    }
-
-    @ViewBuilder
-    private var topBar: some View {
-        HStack {
-            let sideInset: CGFloat = 24
-
-            BackNavigationButton(
-                color: Theme.Colors.textPrimary,
-                insets: EdgeInsets(
-                    top: 0,
-                    leading: sideInset,
-                    bottom: 0,
-                    trailing: 8
-                ),
-                action: {
-                    viewModel.backButtonPressed()
-                }
-            )
-            .frame(width: 32 + sideInset, height: 40)
-
-            Text(ProfileLocalization.Settings.appearanceSettingsTitle)
-                .titleSettings(
-                    top: 0,
-                    bottom: 0,
-                    color: Theme.Colors.textPrimary
-                )
-                .frame(maxWidth: .infinity, alignment: .center)
-                .accessibilityIdentifier("appearance_text")
-                .padding(.trailing, 32 + sideInset)
-        }
-        .padding(.bottom, 4)
     }
 
     @ViewBuilder

--- a/Profile/Profile/Presentation/Settings/AppearanceSettingsView.swift
+++ b/Profile/Profile/Presentation/Settings/AppearanceSettingsView.swift
@@ -1,0 +1,112 @@
+//
+//  AppearanceSettingsView.swift
+//  Profile
+//
+//  Created by Muhammad Tayyab Akram on 5/23/25.
+//
+
+import SwiftUI
+import Core
+import Theme
+
+public struct AppearanceSettingsView: View {
+    @ObservedObject
+    private var viewModel: AppearanceSettingsViewModel
+
+    public init(viewModel: AppearanceSettingsViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .top) {
+                VStack {
+                    topBar
+                    content(geometry: proxy)
+                }
+            }
+            .hideNavigationBar(true)
+            .navigationBarBackButtonHidden(true)
+            .navigationTitle(ProfileLocalization.Settings.appearanceSettingsTitle)
+        }
+        .background(
+            Theme.Colors.background
+                .ignoresSafeArea()
+        )
+    }
+
+    @ViewBuilder
+    private var topBar: some View {
+        HStack {
+            let sideInset: CGFloat = 24
+
+            BackNavigationButton(
+                color: Theme.Colors.textPrimary,
+                insets: EdgeInsets(
+                    top: 0,
+                    leading: sideInset,
+                    bottom: 0,
+                    trailing: 8
+                ),
+                action: {
+                    viewModel.backButtonPressed()
+                }
+            )
+            .frame(width: 32 + sideInset, height: 40)
+
+            Text(ProfileLocalization.Settings.appearanceSettingsTitle)
+                .titleSettings(
+                    top: 0,
+                    bottom: 0,
+                    color: Theme.Colors.textPrimary
+                )
+                .frame(maxWidth: .infinity, alignment: .center)
+                .accessibilityIdentifier("appearance_text")
+                .padding(.trailing, 32 + sideInset)
+        }
+        .padding(.bottom, 4)
+    }
+
+    @ViewBuilder
+    private func content(geometry: GeometryProxy) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                ForEach(AppearanceMenu.allCases, id: \.self) { menu in
+                    Button(action: {
+                        viewModel.menuSelected(menu)
+                    }, label: {
+                        HStack {
+                            SettingsCell(
+                                title: menu.title,
+                                description: menu.description
+                            )
+                            Spacer()
+                            CoreAssets.checkmark.swiftUIImage
+                                .renderingMode(.template)
+                                .foregroundColor(Theme.Colors.accentXColor)
+                                .opacity(viewModel.selectedMenu == menu ? 1 : 0)
+                        }.foregroundColor(Theme.Colors.textPrimary)
+                    })
+                    .accessibilityIdentifier("select_appearance_button")
+
+                    Divider()
+                }
+            }
+            .frameLimit(width: geometry.size.width)
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    AppearanceSettingsView(
+        viewModel: AppearanceSettingsViewModel(
+            themeManager: ThemeManagerMock(),
+            router: ProfileRouterMock(),
+            analytics: ProfileAnalyticsMock()
+        )
+    )
+}
+#endif

--- a/Profile/Profile/Presentation/Settings/AppearanceSettingsViewModel.swift
+++ b/Profile/Profile/Presentation/Settings/AppearanceSettingsViewModel.swift
@@ -1,0 +1,94 @@
+//
+//  AppearanceSettingsViewModel.swift
+//  Profile
+//
+//  Created by Muhammad Tayyab Akram on 5/23/25.
+//
+
+import Foundation
+import Core
+
+public final class AppearanceSettingsViewModel: ObservableObject {
+    @Published private(set) var selectedMenu: AppearanceMenu
+
+    private var themeManager: ThemeManagerProtocol
+    private let router: ProfileRouter
+    private let analytics: ProfileAnalytics
+
+    public init(
+        themeManager: ThemeManagerProtocol,
+        router: ProfileRouter,
+        analytics: ProfileAnalytics
+    ) {
+        self.themeManager = themeManager
+        self.router = router
+        self.analytics = analytics
+
+        switch themeManager.currentTheme {
+        case .light:
+            selectedMenu = .lightMode
+        case .dark:
+            selectedMenu = .darkMode
+        case .system:
+            selectedMenu = .matchDevice
+        }
+    }
+
+    func backButtonPressed() {
+        router.back()
+    }
+
+    func menuSelected(_ menu: AppearanceMenu) {
+        let oldTheme = themeManager.currentTheme
+        let newTheme = menu.appTheme
+
+        selectedMenu = menu
+        themeManager.currentTheme = newTheme
+
+        trackAppThemeChanged(to: newTheme, from: oldTheme)
+    }
+
+    private func trackAppThemeChanged(to newTheme: AppTheme, from oldTheme: AppTheme) {
+        analytics.profileAppThemeChanged(
+            newMode: newTheme.analyticsValue,
+            previousMode: oldTheme.analyticsValue
+        )
+    }
+}
+
+enum AppearanceMenu: CaseIterable {
+    case lightMode
+    case darkMode
+    case matchDevice
+
+    var appTheme: AppTheme {
+        switch self {
+        case .lightMode:
+            return .light
+        case .darkMode:
+            return .dark
+        case .matchDevice:
+            return .system
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .lightMode:
+            return ProfileLocalization.Settings.appearanceLightMode
+        case .darkMode:
+            return ProfileLocalization.Settings.appearanceDarkMode
+        case .matchDevice:
+            return ProfileLocalization.Settings.appearanceMatchDevice
+        }
+    }
+
+    var description: String? {
+        switch self {
+        case .lightMode, .darkMode:
+            return nil
+        case .matchDevice:
+            return ProfileLocalization.Settings.appearanceMatchesDeviceSettings
+        }
+    }
+}

--- a/Profile/Profile/Presentation/Settings/SettingsView.swift
+++ b/Profile/Profile/Presentation/Settings/SettingsView.swift
@@ -208,6 +208,21 @@ public struct SettingsView: View {
                 })
                 .accessibilityIdentifier("push_notifications_settings_button")
             }
+
+            Divider()
+
+            Button(action: {
+                viewModel.trackAppearanceSettingsClicked()
+                viewModel.router.showAppearanceSettings()
+            }, label: {
+                HStack {
+                    Text(ProfileLocalization.Settings.appearanceSettingsTitle)
+                        .font(Theme.Fonts.titleMedium)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                }
+            })
+            .accessibilityIdentifier("appearance_settings_button")
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(ProfileLocalization.settingsVideo)

--- a/Profile/Profile/Presentation/Settings/SettingsViewModel.swift
+++ b/Profile/Profile/Presentation/Settings/SettingsViewModel.swift
@@ -160,7 +160,14 @@ public class SettingsViewModel: ObservableObject {
             biValue: .profilePushSettingsClicked
         )
     }
-    
+
+    func trackAppearanceSettingsClicked() {
+        analytics.profileTrackEvent(
+            .profileAppearanceSettingClicked,
+            biValue: .profileAppearanceSettingClicked
+        )
+    }
+
     func trackEmailSupportClicked() {
         analytics.emailSupportClicked()
     }

--- a/Profile/Profile/SwiftGen/Strings.swift
+++ b/Profile/Profile/SwiftGen/Strings.swift
@@ -256,6 +256,16 @@ public enum ProfileLocalization {
     public static let useRelativeDates = ProfileLocalization.tr("Localizable", "OPTIONS.USE_RELATIVE_DATES", fallback: "Use relative dates")
   }
   public enum Settings {
+    /// Dark Mode
+    public static let appearanceDarkMode = ProfileLocalization.tr("Localizable", "SETTINGS.APPEARANCE_DARK_MODE", fallback: "Dark Mode")
+    /// Light Mode
+    public static let appearanceLightMode = ProfileLocalization.tr("Localizable", "SETTINGS.APPEARANCE_LIGHT_MODE", fallback: "Light Mode")
+    /// Match Device
+    public static let appearanceMatchDevice = ProfileLocalization.tr("Localizable", "SETTINGS.APPEARANCE_MATCH_DEVICE", fallback: "Match Device")
+    /// Matches your device settings automatically.
+    public static let appearanceMatchesDeviceSettings = ProfileLocalization.tr("Localizable", "SETTINGS.APPEARANCE_MATCHES_DEVICE_SETTINGS", fallback: "Matches your device settings automatically.")
+    /// Appearance
+    public static let appearanceSettingsTitle = ProfileLocalization.tr("Localizable", "SETTINGS.APPEARANCE_SETTINGS_TITLE", fallback: "Appearance")
     /// Push Notifications
     public static let pushSettingsTitle = ProfileLocalization.tr("Localizable", "SETTINGS.PUSH_SETTINGS_TITLE", fallback: "Push Notifications")
     /// Lower data usage

--- a/Profile/Profile/en.lproj/Localizable.strings
+++ b/Profile/Profile/en.lproj/Localizable.strings
@@ -66,11 +66,17 @@
 "DELETE_ACCOUNT.INCORRECT_PASSWORD" = "The password is incorrect. Please try again.";
 
 "SETTINGS.VIDEO_SETTINGS_TITLE" = "Video settings";
+"SETTINGS.APPEARANCE_SETTINGS_TITLE" = "Appearance";
 "SETTINGS.PUSH_SETTINGS_TITLE" = "Push Notifications";
 "SETTINGS.WIFI_TITLE" = "Wi-fi only download";
 "SETTINGS.WIFI_DESCRIPTION" = "Only download content when wi-fi is turned on";
 "SETTINGS.VIDEO_QUALITY_TITLE" = "Video streaming quality";
 "SETTINGS.VIDEO_QUALITY_DESCRIPTION" = "Auto (Recommended)";
+
+"SETTINGS.APPEARANCE_LIGHT_MODE" = "Light Mode";
+"SETTINGS.APPEARANCE_DARK_MODE" = "Dark Mode";
+"SETTINGS.APPEARANCE_MATCH_DEVICE" = "Match Device";
+"SETTINGS.APPEARANCE_MATCHES_DEVICE_SETTINGS" = "Matches your device settings automatically.";
 
 "SETTINGS.QUALITY_AUTO_TITLE" = "Auto";
 "SETTINGS.QUALITY_AUTO_DESCRIPTION" = "Recommended";

--- a/Profile/Profile/uk.lproj/Localizable.strings
+++ b/Profile/Profile/uk.lproj/Localizable.strings
@@ -65,10 +65,16 @@
 "DELETE_ACCOUNT.INCORRECT_PASSWORD" = "Пароль неправильний. Будь ласка спробуйте ще раз.";
 
 "SETTINGS.VIDEO_SETTINGS_TITLE" = "Налаштування відео";
+"SETTINGS.APPEARANCE_SETTINGS_TITLE" = "Appearance";
 "SETTINGS.WIFI_TITLE" = "Тільки Wi-fi";
 "SETTINGS.WIFI_DESCRIPTION" = "Завантажувати відео, лише коли Wi-Fi увімкнено";
 "SETTINGS.VIDEO_QUALITY_TITLE" = "Якість потокового відео";
 "SETTINGS.VIDEO_QUALITY_DESCRIPTION" = "Авто (Рекомендовано)";
+
+"SETTINGS.APPEARANCE_LIGHT_MODE" = "Light Mode";
+"SETTINGS.APPEARANCE_DARK_MODE" = "Dark Mode";
+"SETTINGS.APPEARANCE_MATCH_DEVICE" = "Match Device";
+"SETTINGS.APPEARANCE_MATCHES_DEVICE_SETTINGS" = "Matches your device settings automatically.";
 
 "SETTINGS.QUALITY_AUTO_TITLE" = "Авто";
 "SETTINGS.QUALITY_AUTO_DESCRIPTION" = "Рекомендовано";

--- a/Profile/ProfileTests/ProfileMock.generated.swift
+++ b/Profile/ProfileTests/ProfileMock.generated.swift
@@ -3456,6 +3456,12 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
 		perform?(`success`)
     }
 
+    open func profileAppThemeChanged(newMode: String, previousMode: String) {
+        addInvocation(.m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode(Parameter<String>.value(`newMode`), Parameter<String>.value(`previousMode`)))
+		let perform = methodPerformValue(.m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode(Parameter<String>.value(`newMode`), Parameter<String>.value(`previousMode`))) as? (String, String) -> Void
+		perform?(`newMode`, `previousMode`)
+    }
+
     open func profileTrackEvent(_ event: AnalyticsEvent, biValue: EventBIValue) {
         addInvocation(.m_profileTrackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>.value(`event`), Parameter<EventBIValue>.value(`biValue`)))
 		let perform = methodPerformValue(.m_profileTrackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>.value(`event`), Parameter<EventBIValue>.value(`biValue`))) as? (AnalyticsEvent, EventBIValue) -> Void
@@ -3485,6 +3491,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
         case m_profileWifiToggle__action_action(Parameter<String>)
         case m_profileUserDeleteAccountClicked
         case m_profileDeleteAccountSuccess__success_success(Parameter<Bool>)
+        case m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode(Parameter<String>, Parameter<String>)
         case m_profileTrackEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
         case m_profileScreenEvent__eventbiValue_biValue(Parameter<AnalyticsEvent>, Parameter<EventBIValue>)
 
@@ -3532,6 +3539,12 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSuccess, rhs: rhsSuccess, with: matcher), lhsSuccess, rhsSuccess, "success"))
 				return Matcher.ComparisonResult(results)
 
+            case (.m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode(let lhsNewmode, let lhsPreviousmode), .m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode(let rhsNewmode, let rhsPreviousmode)):
+				var results: [Matcher.ParameterComparisonResult] = []
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsNewmode, rhs: rhsNewmode, with: matcher), lhsNewmode, rhsNewmode, "newMode"))
+				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsPreviousmode, rhs: rhsPreviousmode, with: matcher), lhsPreviousmode, rhsPreviousmode, "previousMode"))
+				return Matcher.ComparisonResult(results)
+
             case (.m_profileTrackEvent__eventbiValue_biValue(let lhsEvent, let lhsBivalue), .m_profileTrackEvent__eventbiValue_biValue(let rhsEvent, let rhsBivalue)):
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsEvent, rhs: rhsEvent, with: matcher), lhsEvent, rhsEvent, "_ event"))
@@ -3564,6 +3577,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
             case let .m_profileWifiToggle__action_action(p0): return p0.intValue
             case .m_profileUserDeleteAccountClicked: return 0
             case let .m_profileDeleteAccountSuccess__success_success(p0): return p0.intValue
+            case let .m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode(p0, p1): return p0.intValue + p1.intValue
             case let .m_profileTrackEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             case let .m_profileScreenEvent__eventbiValue_biValue(p0, p1): return p0.intValue + p1.intValue
             }
@@ -3585,6 +3599,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
             case .m_profileWifiToggle__action_action: return ".profileWifiToggle(action:)"
             case .m_profileUserDeleteAccountClicked: return ".profileUserDeleteAccountClicked()"
             case .m_profileDeleteAccountSuccess__success_success: return ".profileDeleteAccountSuccess(success:)"
+            case .m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode: return ".profileAppThemeChanged(newMode:previousMode:)"
             case .m_profileTrackEvent__eventbiValue_biValue: return ".profileTrackEvent(_:biValue:)"
             case .m_profileScreenEvent__eventbiValue_biValue: return ".profileScreenEvent(_:biValue:)"
             }
@@ -3620,6 +3635,7 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
         public static func profileWifiToggle(action: Parameter<String>) -> Verify { return Verify(method: .m_profileWifiToggle__action_action(`action`))}
         public static func profileUserDeleteAccountClicked() -> Verify { return Verify(method: .m_profileUserDeleteAccountClicked)}
         public static func profileDeleteAccountSuccess(success: Parameter<Bool>) -> Verify { return Verify(method: .m_profileDeleteAccountSuccess__success_success(`success`))}
+        public static func profileAppThemeChanged(newMode: Parameter<String>, previousMode: Parameter<String>) -> Verify { return Verify(method: .m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode(`newMode`, `previousMode`))}
         public static func profileTrackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_profileTrackEvent__eventbiValue_biValue(`event`, `biValue`))}
         public static func profileScreenEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>) -> Verify { return Verify(method: .m_profileScreenEvent__eventbiValue_biValue(`event`, `biValue`))}
     }
@@ -3672,6 +3688,9 @@ open class ProfileAnalyticsMock: ProfileAnalytics, Mock {
         }
         public static func profileDeleteAccountSuccess(success: Parameter<Bool>, perform: @escaping (Bool) -> Void) -> Perform {
             return Perform(method: .m_profileDeleteAccountSuccess__success_success(`success`), performs: perform)
+        }
+        public static func profileAppThemeChanged(newMode: Parameter<String>, previousMode: Parameter<String>, perform: @escaping (String, String) -> Void) -> Perform {
+            return Perform(method: .m_profileAppThemeChanged__newMode_newModepreviousMode_previousMode(`newMode`, `previousMode`), performs: perform)
         }
         public static func profileTrackEvent(_ event: Parameter<AnalyticsEvent>, biValue: Parameter<EventBIValue>, perform: @escaping (AnalyticsEvent, EventBIValue) -> Void) -> Perform {
             return Perform(method: .m_profileTrackEvent__eventbiValue_biValue(`event`, `biValue`), performs: perform)
@@ -4394,6 +4413,12 @@ open class ProfileRouterMock: ProfileRouter, Mock {
 		perform?()
     }
 
+    open func showAppearanceSettings() {
+        addInvocation(.m_showAppearanceSettings)
+		let perform = methodPerformValue(.m_showAppearanceSettings) as? () -> Void
+		perform?()
+    }
+
     open func showManageAccount() {
         addInvocation(.m_showManageAccount)
 		let perform = methodPerformValue(.m_showManageAccount) as? () -> Void
@@ -4620,6 +4645,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         case m_showSettings
         case m_showVideoSettings
         case m_showPushSettings
+        case m_showAppearanceSettings
         case m_showManageAccount
         case m_showDatesAndCalendar
         case m_showSyncCalendarOptions
@@ -4670,6 +4696,8 @@ open class ProfileRouterMock: ProfileRouter, Mock {
             case (.m_showVideoSettings, .m_showVideoSettings): return .match
 
             case (.m_showPushSettings, .m_showPushSettings): return .match
+
+            case (.m_showAppearanceSettings, .m_showAppearanceSettings): return .match
 
             case (.m_showManageAccount, .m_showManageAccount): return .match
 
@@ -4852,6 +4880,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
             case .m_showSettings: return 0
             case .m_showVideoSettings: return 0
             case .m_showPushSettings: return 0
+            case .m_showAppearanceSettings: return 0
             case .m_showManageAccount: return 0
             case .m_showDatesAndCalendar: return 0
             case .m_showSyncCalendarOptions: return 0
@@ -4895,6 +4924,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
             case .m_showSettings: return ".showSettings()"
             case .m_showVideoSettings: return ".showVideoSettings()"
             case .m_showPushSettings: return ".showPushSettings()"
+            case .m_showAppearanceSettings: return ".showAppearanceSettings()"
             case .m_showManageAccount: return ".showManageAccount()"
             case .m_showDatesAndCalendar: return ".showDatesAndCalendar()"
             case .m_showSyncCalendarOptions: return ".showSyncCalendarOptions()"
@@ -4952,6 +4982,7 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         public static func showSettings() -> Verify { return Verify(method: .m_showSettings)}
         public static func showVideoSettings() -> Verify { return Verify(method: .m_showVideoSettings)}
         public static func showPushSettings() -> Verify { return Verify(method: .m_showPushSettings)}
+        public static func showAppearanceSettings() -> Verify { return Verify(method: .m_showAppearanceSettings)}
         public static func showManageAccount() -> Verify { return Verify(method: .m_showManageAccount)}
         public static func showDatesAndCalendar() -> Verify { return Verify(method: .m_showDatesAndCalendar)}
         public static func showSyncCalendarOptions() -> Verify { return Verify(method: .m_showSyncCalendarOptions)}
@@ -5014,6 +5045,9 @@ open class ProfileRouterMock: ProfileRouter, Mock {
         }
         public static func showPushSettings(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showPushSettings, performs: perform)
+        }
+        public static func showAppearanceSettings(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_showAppearanceSettings, performs: perform)
         }
         public static func showManageAccount(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showManageAccount, performs: perform)


### PR DESCRIPTION
[LEARNER-10567](https://2u-internal.atlassian.net/browse/LEARNER-10567): Add option to change app appearance (Dark Mode) settings

### Description
This PR introduces a new **Appearance** setting in the app’s Settings screen to allow users to manually control the app’s theme. Users can select from the following options:
- Light Mode
- Dark Mode
- Match Device (follows system setting)

### Screenshots
| iPhone | iPad |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-02 at 18 36 16](https://github.com/user-attachments/assets/a8c9e4e0-4608-4785-97e4-64151c9c11ad) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-06-02 at 18 39 09](https://github.com/user-attachments/assets/9194a24a-0116-4a38-abd4-785176dd6cdc) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-02 at 18 36 28](https://github.com/user-attachments/assets/0be6dfd0-160c-4b72-9cb7-8fa10a9deb74) | ![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-06-02 at 18 39 12](https://github.com/user-attachments/assets/c6dea2be-e38a-4857-9ca5-433bf9896cdc) |
