### PR TITLE
test: Notifications Inbox Screen Unit Tests Implementation

### DIFF
--- a/Course/Course.xcodeproj/project.pbxproj
+++ b/Course/Course.xcodeproj/project.pbxproj
@@ -789,13 +789,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Course-CourseTests/Pods-App-Course-CourseTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Course-CourseTests/Pods-App-Course-CourseTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Notifications/Notifications.xcodeproj/project.pbxproj
+++ b/Notifications/Notifications.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		9704E8082D2BF8C500B28907 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9704E8072D2BF8C100B28907 /* Notifications.swift */; };
 		97243C862D377662000B17C0 /* NotificationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97243C852D377662000B17C0 /* NotificationsResponse.swift */; };
 		973CCD772D3635C000949756 /* SingleNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973CCD762D3635C000949756 /* SingleNotificationView.swift */; };
+		975DF6C12DD4842D00B2ECCF /* NotificationsInboxViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975DF6C02DD4842400B2ECCF /* NotificationsInboxViewModelTests.swift */; };
 		978648CE2D636AD600AB006B /* Discussion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 978648CD2D636AD600AB006B /* Discussion.framework */; };
 		978775242D19A20300D1C21E /* NotificationsInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978775232D19A20300D1C21E /* NotificationsInboxView.swift */; };
 		978775262D19A21D00D1C21E /* NotificationsInboxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978775252D19A21D00D1C21E /* NotificationsInboxViewModel.swift */; };
@@ -81,6 +82,7 @@
 		9704E8072D2BF8C100B28907 /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		97243C852D377662000B17C0 /* NotificationsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsResponse.swift; sourceTree = "<group>"; };
 		973CCD762D3635C000949756 /* SingleNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleNotificationView.swift; sourceTree = "<group>"; };
+		975DF6C02DD4842400B2ECCF /* NotificationsInboxViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsInboxViewModelTests.swift; sourceTree = "<group>"; };
 		978648CD2D636AD600AB006B /* Discussion.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Discussion.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		978775232D19A20300D1C21E /* NotificationsInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsInboxView.swift; sourceTree = "<group>"; };
 		978775252D19A21D00D1C21E /* NotificationsInboxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsInboxViewModel.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 		022D04882976D7E100E0059B /* NotificationsTests */ = {
 			isa = PBXGroup;
 			children = (
+				975DF6BF2DD4838300B2ECCF /* Presentation */,
 				022D04972976DA8A00E0059B /* NotificationsMock.generated.swift */,
 			);
 			path = NotificationsTests;
@@ -294,6 +297,14 @@
 				9704E8072D2BF8C100B28907 /* Notifications.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		975DF6BF2DD4838300B2ECCF /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				975DF6C02DD4842400B2ECCF /* NotificationsInboxViewModelTests.swift */,
+			);
+			path = Presentation;
 			sourceTree = "<group>";
 		};
 		978775222D19A06F00D1C21E /* NotificationsInbox */ = {
@@ -513,6 +524,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				975DF6C12DD4842D00B2ECCF /* NotificationsInboxViewModelTests.swift in Sources */,
 				022D04982976DA8A00E0059B /* NotificationsMock.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -31,7 +31,7 @@ public class NotificationsInboxViewModel: ObservableObject {
     private var interactor: NotificationsInteractorProtocol
     private var cancellables = Set<AnyCancellable>()
     private(set) var lazyVStackUniqueID: String = UUID().uuidString
-    private var flatNotifications: [SingleNotification] = [] {
+    var flatNotifications: [SingleNotification] = [] {
         didSet { groupItems() }
     }
     

--- a/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
+++ b/Notifications/Notifications/Presentation/NotificationsInbox/NotificationsInboxViewModel.swift
@@ -31,7 +31,7 @@ public class NotificationsInboxViewModel: ObservableObject {
     private var interactor: NotificationsInteractorProtocol
     private var cancellables = Set<AnyCancellable>()
     private(set) var lazyVStackUniqueID: String = UUID().uuidString
-    var flatNotifications: [SingleNotification] = [] {
+    private(set) var flatNotifications: [SingleNotification] = [] {
         didSet { groupItems() }
     }
     

--- a/Notifications/NotificationsTests/Presentation/NotificationsInboxViewModelTests.swift
+++ b/Notifications/NotificationsTests/Presentation/NotificationsInboxViewModelTests.swift
@@ -13,7 +13,7 @@ import Alamofire
 
 final class NotificationsInboxViewModelTests: XCTestCase {
     private var mockInteractor: NotificationsInteractorProtocolMock!
-    private var viewModel: NotificationsInboxViewModel!
+    private var sut: NotificationsInboxViewModel!
     private var mockConnectivity: ConnectivityProtocolMock!
     
     private let notifications = Notifications(
@@ -39,7 +39,8 @@ final class NotificationsInboxViewModelTests: XCTestCase {
                 lastRead: nil,
                 lastSeen: Date(iso8601: "2025-01-06T01:20:58.919612Z"),
                 created: Date(iso8601: "2025-01-06T01:20:58.919612Z")
-            ), SingleNotification(
+            ),
+            SingleNotification(
                 id: 2,
                 appName: "discussion",
                 notificationType: "response_on_followed_post",
@@ -55,7 +56,8 @@ final class NotificationsInboxViewModelTests: XCTestCase {
                 lastRead: nil,
                 lastSeen: Date(iso8601: "2025-01-06T01:20:58.919612Z"),
                 created: Date(iso8601: "2025-01-06T01:20:58.919612Z")
-            ), SingleNotification(
+            ),
+            SingleNotification(
                 id: 3,
                 appName: "discussion",
                 notificationType: "new_response",
@@ -71,7 +73,8 @@ final class NotificationsInboxViewModelTests: XCTestCase {
                 lastRead: nil,
                 lastSeen: Date(iso8601: "2025-01-06T01:20:58.919612Z"),
                 created: Date(iso8601: "2025-01-06T01:20:58.919612Z")
-            ), SingleNotification(
+            ),
+            SingleNotification(
                 id: 4,
                 appName: "discussion",
                 notificationType: "new_comment",
@@ -98,71 +101,56 @@ final class NotificationsInboxViewModelTests: XCTestCase {
         
         Given(mockInteractor, .getAllNotifications(page: 1, willReturn: notifications))
         
-        viewModel = NotificationsInboxViewModel(
+        sut = NotificationsInboxViewModel(
             notificationsInteractor: mockInteractor,
             analytics: NotificationsAnalyticsMock(),
             router: NotificationsRouterMock(),
-            connectivity: Connectivity(),
+            connectivity: mockConnectivity,
             deepLinkManager: NotificationsDeepLinkManagerMock()
         )
     }
     
     override func tearDown() {
         mockInteractor = nil
-        viewModel = nil
+        sut = nil
         super.tearDown()
-    }
-    
-    private func makeSUT(
-        interactor: NotificationsInteractorProtocol = NotificationsInteractorProtocolMock(),
-        analytics: NotificationsAnalytics = NotificationsAnalyticsMock(),
-        router: NotificationsRouter = NotificationsRouterMock(),
-        connectivity: ConnectivityProtocol = ConnectivityProtocolMock(),
-        deepLinkManager: NotificationsDeepLinkManager = NotificationsDeepLinkManagerMock(),
-        paginationManager: PaginationManager<SingleNotification, Int>? = nil
-    ) -> NotificationsInboxViewModel {
-        let sut = NotificationsInboxViewModel(
-            notificationsInteractor: interactor,
-            analytics: analytics,
-            router: router,
-            connectivity: connectivity,
-            deepLinkManager: deepLinkManager
-        )        
-        return sut
     }
     
     func testMarkNotificationAsReadSuccess() async throws {
         let expectedResponse = NotificationsSeenRead(message: "Notification marked read.")
         
-        Given(mockInteractor, .markNotificationAsRead(notificationId: .any, willReturn: expectedResponse))
+        Given(mockInteractor, .markNotificationAsRead(notificationId: .value("1"), willReturn: expectedResponse))
         
-        await viewModel.markNotificationAsRead(notificationId: "1")
+        await sut.markNotificationAsRead(notificationId: "1")
         
-        Verify(mockInteractor, .markNotificationAsRead(notificationId: .any))
+        Verify(mockInteractor, 1, .markNotificationAsRead(notificationId: .value("1")))
+        
+        XCTAssertNil(sut.errorMessage)
     }
     
     func testMarkNotificationAsReadNoInternetError() async throws {
         let noInternetError = AFError.sessionInvalidated(error: URLError(.notConnectedToInternet))
         
-        Given(mockInteractor, .markNotificationAsRead(notificationId: .any, willThrow: noInternetError))
+        Given(mockInteractor, .markNotificationAsRead(notificationId: .value("1"), willThrow: noInternetError))
         
-        await viewModel.markNotificationAsRead(notificationId: "1")
+        await sut.markNotificationAsRead(notificationId: "1")
         
-        Verify(mockInteractor, .markNotificationAsRead(notificationId: .any))
+        Verify(mockInteractor, 1, .markNotificationAsRead(notificationId: .value("1")))
         
-        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertEqual(sut.errorMessage, CoreLocalization.Error.slowOrNoInternetConnection)
     }
     
     func testMarkNotificationAsReadUnknownError() async throws {
-        let noInternetError = AFError.sessionInvalidated(error: NSError(domain: "error", code: -1, userInfo: nil))
+        let unknown = AFError.sessionInvalidated(error: NSError(domain: "error", code: -1, userInfo: nil))
         
-        Given(mockInteractor, .markNotificationAsRead(notificationId: .any, willThrow: noInternetError))
+        Given(mockInteractor, .markNotificationAsRead(notificationId: .value("1"), willThrow: unknown))
         
-        await viewModel.markNotificationAsRead(notificationId: "1")
+        await sut.markNotificationAsRead(notificationId: "1")
         
-        Verify(mockInteractor, .markNotificationAsRead(notificationId: .any))
+        Verify(mockInteractor, 1, .markNotificationAsRead(notificationId: .value("1")))
         
-        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertNotNil(sut.errorMessage)
     }
     
     func testMarkAllNotificationsAsReadSuccess() async throws {
@@ -170,35 +158,44 @@ final class NotificationsInboxViewModelTests: XCTestCase {
         
         Given(mockInteractor, .markAllNotificationsAsRead(willReturn: expectedResponse))
         
-        await viewModel.loadNotifications()
-        await viewModel.markAllNotificationsAsRead()
+        await sut.loadNotifications()
+        await sut.markAllNotificationsAsRead()
         
-        Verify(mockInteractor, .markAllNotificationsAsRead())
+        Verify(mockInteractor, 1, .markAllNotificationsAsRead())
         
-        XCTAssertNotNil(viewModel.flatNotifications[0].lastRead)
-        XCTAssertEqual(notifications.results?.count, viewModel.flatNotifications.count)
+        XCTAssertNotNil(sut.flatNotifications[0].lastRead)
+        XCTAssertNotNil(sut.flatNotifications[1].lastRead)
+        XCTAssertNotNil(sut.flatNotifications[2].lastRead)
+        XCTAssertNotNil(sut.flatNotifications[3].lastRead)
+        XCTAssertEqual(notifications.results?.count, sut.flatNotifications.count)
+        XCTAssertNil(sut.errorMessage)
     }
     
     func testMarkAllNotificationsAsReadNoInternetError() async throws {
-        Given(mockInteractor, .markAllNotificationsAsRead(willThrow: URLError(.notConnectedToInternet)))
+        let noInternetError = AFError.sessionInvalidated(error: URLError(.notConnectedToInternet))
         
-        await viewModel.loadNotifications()
-        await viewModel.markAllNotificationsAsRead()
+        Given(mockInteractor, .markAllNotificationsAsRead(willThrow: noInternetError))
         
-        Verify(mockInteractor, .markAllNotificationsAsRead())
+        await sut.loadNotifications()
+        await sut.markAllNotificationsAsRead()
         
-        XCTAssertNotNil(viewModel.errorMessage)
+        Verify(mockInteractor, 1, .markAllNotificationsAsRead())
+        
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertEqual(sut.errorMessage, CoreLocalization.Error.slowOrNoInternetConnection)
     }
     
     func testMarkAllNotificationsAsReadUnknownError() async throws {
-        Given(mockInteractor, .markAllNotificationsAsRead(willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        let unknown = AFError.sessionInvalidated(error: NSError(domain: "error", code: -1, userInfo: nil))
         
-        await viewModel.loadNotifications()
-        await viewModel.markAllNotificationsAsRead()
+        Given(mockInteractor, .markAllNotificationsAsRead(willThrow: unknown))
         
-        Verify(mockInteractor, .markAllNotificationsAsRead())
+        await sut.loadNotifications()
+        await sut.markAllNotificationsAsRead()
         
-        XCTAssertNotNil(viewModel.errorMessage)
+        Verify(mockInteractor, 1, .markAllNotificationsAsRead())
+        
+        XCTAssertNotNil(sut.errorMessage)
     }
     
     func testMarkNotificationsAsSeenSuccess() async throws {
@@ -206,104 +203,57 @@ final class NotificationsInboxViewModelTests: XCTestCase {
         
         Given(mockInteractor, .markNotificationsAsSeen(willReturn: expectedResponse))
         
-        await viewModel.markNotificationsAsSeen()
+        await sut.markNotificationsAsSeen()
         
-        Verify(mockInteractor, .markNotificationsAsSeen())
+        Verify(mockInteractor, 1, .markNotificationsAsSeen())
     }
     
     func testMarkNotificationsAsSeenNoInternetError() async throws {
-        Given(mockInteractor, .markNotificationsAsSeen(willThrow: URLError(.notConnectedToInternet)))
+        let noInternetError = AFError.sessionInvalidated(error: URLError(.notConnectedToInternet))
         
-        await viewModel.markNotificationsAsSeen()
+        Given(mockInteractor, .markNotificationsAsSeen(willThrow: noInternetError))
         
-        Verify(mockInteractor, .markNotificationsAsSeen())
+        await sut.markNotificationsAsSeen()
+        
+        Verify(mockInteractor, 1, .markNotificationsAsSeen())
     }
     
     func testMarkNotificationsAsSeenUnknownError() async throws {
-        Given(mockInteractor, .markNotificationsAsSeen(willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        let unknown = AFError.sessionInvalidated(error: NSError(domain: "error", code: -1, userInfo: nil))
         
-        await viewModel.markNotificationsAsSeen()
+        Given(mockInteractor, .markNotificationsAsSeen(willThrow: unknown))
         
-        Verify(mockInteractor, .markNotificationsAsSeen())
+        await sut.markNotificationsAsSeen()
+        
+        Verify(mockInteractor, 1, .markNotificationsAsSeen())
     }
     
     func testGetAllNotificationsSuccess() async throws {
-        Given(mockInteractor, .getAllNotifications(page: 1, willReturn: notifications))
+        await sut.loadNotifications()
         
-        viewModel = NotificationsInboxViewModel(
-            notificationsInteractor: mockInteractor,
-            analytics: NotificationsAnalyticsMock(),
-            router: NotificationsRouterMock(),
-            connectivity: Connectivity(),
-            deepLinkManager: NotificationsDeepLinkManagerMock()
-        )
-
-        await viewModel.loadNotifications()
-        
-        XCTAssertEqual(notifications.results?.count, viewModel.flatNotifications.count)
+        XCTAssertEqual(notifications.results?.count, sut.flatNotifications.count)
+        XCTAssertNil(sut.errorMessage)
     }
     
     func testGetAllNotificationsNoInternetError() async throws {
-        Given(mockInteractor, .getAllNotifications(page: 1, willThrow: URLError(.notConnectedToInternet)))
+        let noInternetError = AFError.sessionInvalidated(error: URLError(.notConnectedToInternet))
+        
+        Given(mockInteractor, .getAllNotifications(page: 1, willThrow: noInternetError))
         Given(mockConnectivity, .isInternetAvaliable(getter: false))
         
-        viewModel = NotificationsInboxViewModel(
-            notificationsInteractor: mockInteractor,
-            analytics: NotificationsAnalyticsMock(),
-            router: NotificationsRouterMock(),
-            connectivity: mockConnectivity,
-            deepLinkManager: NotificationsDeepLinkManagerMock()
-        )
-
-        await viewModel.loadNotifications()
+        await sut.loadNotifications()
         
-        XCTAssertEqual(viewModel.screenState, .noInternet)
+        XCTAssertEqual(sut.screenState, .noInternet)
     }
     
     func testGetAllNotificationsUnknownError() async throws {
-        Given(mockInteractor, .getAllNotifications(page: 1, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        let unknown = AFError.sessionInvalidated(error: NSError(domain: "error", code: -1, userInfo: nil))
+        
+        Given(mockInteractor, .getAllNotifications(page: 1, willThrow: unknown))
         Given(mockConnectivity, .isInternetAvaliable(getter: true))
         
-        viewModel = NotificationsInboxViewModel(
-            notificationsInteractor: mockInteractor,
-            analytics: NotificationsAnalyticsMock(),
-            router: NotificationsRouterMock(),
-            connectivity: mockConnectivity,
-            deepLinkManager: NotificationsDeepLinkManagerMock()
-        )
-
-        await viewModel.loadNotifications()
+        await sut.loadNotifications()
         
-        XCTAssertEqual(viewModel.screenState, .serverError)
-    }
-    
-    func testIsDiscussionNotification() async throws {
-        await viewModel.loadNotifications()
-        
-        XCTAssertEqual(viewModel.flatNotifications[0].appName, "discussion")
-    }
-    
-    func testNotificationTypeAsCommentOnFollowedPost() async throws {
-        await viewModel.loadNotifications()
-        
-        XCTAssertEqual(viewModel.flatNotifications[0].notificationType, "comment_on_followed_post")
-    }
-    
-    func testNotificationTypeAsResponseOnFollowedPost() async throws {
-        await viewModel.loadNotifications()
-        
-        XCTAssertEqual(viewModel.flatNotifications[1].notificationType, "response_on_followed_post")
-    }
-    
-    func testNotificationTypeAsNewResponse() async throws {
-        await viewModel.loadNotifications()
-        
-        XCTAssertEqual(viewModel.flatNotifications[2].notificationType, "new_response")
-    }
-    
-    func testNotificationTypeAsNewComment() async throws {
-        await viewModel.loadNotifications()
-        
-        XCTAssertEqual(viewModel.flatNotifications[3].notificationType, "new_comment")
+        XCTAssertEqual(sut.screenState, .serverError)
     }
 }

--- a/Notifications/NotificationsTests/Presentation/NotificationsInboxViewModelTests.swift
+++ b/Notifications/NotificationsTests/Presentation/NotificationsInboxViewModelTests.swift
@@ -1,0 +1,309 @@
+//
+//  NotificationsInboxViewModelTests.swift
+//  Notifications
+//
+//  Created by Shafqat Muneer on 5/14/25.
+//
+
+import SwiftyMocky
+import XCTest
+@testable import Core
+@testable import Notifications
+import Alamofire
+
+final class NotificationsInboxViewModelTests: XCTestCase {
+    private var mockInteractor: NotificationsInteractorProtocolMock!
+    private var viewModel: NotificationsInboxViewModel!
+    private var mockConnectivity: ConnectivityProtocolMock!
+    
+    private let notifications = Notifications(
+        next: nil,
+        count: 4,
+        numPages: 1,
+        currentPage: 1,
+        start: 0,
+        results: [
+            SingleNotification(
+                id: 1,
+                appName: "discussion",
+                notificationType: "comment_on_followed_post",
+                contentContext: ContentContext(
+                    topicId: "i4x-edX-demoX1-course-2T2017",
+                    responseId: "6777c03a7febe504707971ab",
+                    threadId: "5d49c25584452a0795000386",
+                    commentId: "677b2ffa7febe50470799585",
+                    postTitle: "How to learn it online?"
+                ),
+                content: "Test notification One",
+                courseId: "course-v1:edX+Test+2T2009",
+                lastRead: nil,
+                lastSeen: Date(iso8601: "2025-01-06T01:20:58.919612Z"),
+                created: Date(iso8601: "2025-01-06T01:20:58.919612Z")
+            ), SingleNotification(
+                id: 2,
+                appName: "discussion",
+                notificationType: "response_on_followed_post",
+                contentContext: ContentContext(
+                    topicId: "i4x-edX-demoX1-course-2T2017",
+                    responseId: "6777c03a7febe504707971ab",
+                    threadId: "5d49c25584452a0795000386",
+                    commentId: "677b2ffa7febe50470799585",
+                    postTitle: "How to learn it online?"
+                ),
+                content: "Test notification Two",
+                courseId: "course-v1:edX+Test+2T2009",
+                lastRead: nil,
+                lastSeen: Date(iso8601: "2025-01-06T01:20:58.919612Z"),
+                created: Date(iso8601: "2025-01-06T01:20:58.919612Z")
+            ), SingleNotification(
+                id: 3,
+                appName: "discussion",
+                notificationType: "new_response",
+                contentContext: ContentContext(
+                    topicId: "i4x-edX-demoX1-course-2T2017",
+                    responseId: "6777c03a7febe504707971ab",
+                    threadId: "5d49c25584452a0795000386",
+                    commentId: "677b2ffa7febe50470799585",
+                    postTitle: "How to learn it online?"
+                ),
+                content: "Test notification Three",
+                courseId: "course-v1:edX+Test+2T2009",
+                lastRead: nil,
+                lastSeen: Date(iso8601: "2025-01-06T01:20:58.919612Z"),
+                created: Date(iso8601: "2025-01-06T01:20:58.919612Z")
+            ), SingleNotification(
+                id: 4,
+                appName: "discussion",
+                notificationType: "new_comment",
+                contentContext: ContentContext(
+                    topicId: "i4x-edX-demoX1-course-2T2017",
+                    responseId: "6777c03a7febe504707971ab",
+                    threadId: "5d49c25584452a0795000386",
+                    commentId: "677b2ffa7febe50470799585",
+                    postTitle: "How to learn it online?"
+                ),
+                content: "Test notification Three",
+                courseId: "course-v1:edX+Test+2T2009",
+                lastRead: nil,
+                lastSeen: Date(iso8601: "2025-01-06T01:20:58.919612Z"),
+                created: Date(iso8601: "2025-01-06T01:20:58.919612Z")
+            )
+        ]
+    )
+    
+    override func setUp() {
+        super.setUp()
+        mockInteractor = NotificationsInteractorProtocolMock()
+        mockConnectivity = ConnectivityProtocolMock()
+        
+        Given(mockInteractor, .getAllNotifications(page: 1, willReturn: notifications))
+        
+        viewModel = NotificationsInboxViewModel(
+            notificationsInteractor: mockInteractor,
+            analytics: NotificationsAnalyticsMock(),
+            router: NotificationsRouterMock(),
+            connectivity: Connectivity(),
+            deepLinkManager: NotificationsDeepLinkManagerMock()
+        )
+    }
+    
+    override func tearDown() {
+        mockInteractor = nil
+        viewModel = nil
+        super.tearDown()
+    }
+    
+    private func makeSUT(
+        interactor: NotificationsInteractorProtocol = NotificationsInteractorProtocolMock(),
+        analytics: NotificationsAnalytics = NotificationsAnalyticsMock(),
+        router: NotificationsRouter = NotificationsRouterMock(),
+        connectivity: ConnectivityProtocol = ConnectivityProtocolMock(),
+        deepLinkManager: NotificationsDeepLinkManager = NotificationsDeepLinkManagerMock(),
+        paginationManager: PaginationManager<SingleNotification, Int>? = nil
+    ) -> NotificationsInboxViewModel {
+        let sut = NotificationsInboxViewModel(
+            notificationsInteractor: interactor,
+            analytics: analytics,
+            router: router,
+            connectivity: connectivity,
+            deepLinkManager: deepLinkManager
+        )        
+        return sut
+    }
+    
+    func testMarkNotificationAsReadSuccess() async throws {
+        let expectedResponse = NotificationsSeenRead(message: "Notification marked read.")
+        
+        Given(mockInteractor, .markNotificationAsRead(notificationId: .any, willReturn: expectedResponse))
+        
+        await viewModel.markNotificationAsRead(notificationId: "1")
+        
+        Verify(mockInteractor, .markNotificationAsRead(notificationId: .any))
+    }
+    
+    func testMarkNotificationAsReadNoInternetError() async throws {
+        let noInternetError = AFError.sessionInvalidated(error: URLError(.notConnectedToInternet))
+        
+        Given(mockInteractor, .markNotificationAsRead(notificationId: .any, willThrow: noInternetError))
+        
+        await viewModel.markNotificationAsRead(notificationId: "1")
+        
+        Verify(mockInteractor, .markNotificationAsRead(notificationId: .any))
+        
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+    
+    func testMarkNotificationAsReadUnknownError() async throws {
+        let noInternetError = AFError.sessionInvalidated(error: NSError(domain: "error", code: -1, userInfo: nil))
+        
+        Given(mockInteractor, .markNotificationAsRead(notificationId: .any, willThrow: noInternetError))
+        
+        await viewModel.markNotificationAsRead(notificationId: "1")
+        
+        Verify(mockInteractor, .markNotificationAsRead(notificationId: .any))
+        
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+    
+    func testMarkAllNotificationsAsReadSuccess() async throws {
+        let expectedResponse = NotificationsSeenRead(message: "Notifications marked read.")
+        
+        Given(mockInteractor, .markAllNotificationsAsRead(willReturn: expectedResponse))
+        
+        await viewModel.loadNotifications()
+        await viewModel.markAllNotificationsAsRead()
+        
+        Verify(mockInteractor, .markAllNotificationsAsRead())
+        
+        XCTAssertNotNil(viewModel.flatNotifications[0].lastRead)
+        XCTAssertEqual(notifications.results?.count, viewModel.flatNotifications.count)
+    }
+    
+    func testMarkAllNotificationsAsReadNoInternetError() async throws {
+        Given(mockInteractor, .markAllNotificationsAsRead(willThrow: URLError(.notConnectedToInternet)))
+        
+        await viewModel.loadNotifications()
+        await viewModel.markAllNotificationsAsRead()
+        
+        Verify(mockInteractor, .markAllNotificationsAsRead())
+        
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+    
+    func testMarkAllNotificationsAsReadUnknownError() async throws {
+        Given(mockInteractor, .markAllNotificationsAsRead(willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        
+        await viewModel.loadNotifications()
+        await viewModel.markAllNotificationsAsRead()
+        
+        Verify(mockInteractor, .markAllNotificationsAsRead())
+        
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+    
+    func testMarkNotificationsAsSeenSuccess() async throws {
+        let expectedResponse = NotificationsSeenRead(message: "Notifications marked as seen.")
+        
+        Given(mockInteractor, .markNotificationsAsSeen(willReturn: expectedResponse))
+        
+        await viewModel.markNotificationsAsSeen()
+        
+        Verify(mockInteractor, .markNotificationsAsSeen())
+    }
+    
+    func testMarkNotificationsAsSeenNoInternetError() async throws {
+        Given(mockInteractor, .markNotificationsAsSeen(willThrow: URLError(.notConnectedToInternet)))
+        
+        await viewModel.markNotificationsAsSeen()
+        
+        Verify(mockInteractor, .markNotificationsAsSeen())
+    }
+    
+    func testMarkNotificationsAsSeenUnknownError() async throws {
+        Given(mockInteractor, .markNotificationsAsSeen(willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        
+        await viewModel.markNotificationsAsSeen()
+        
+        Verify(mockInteractor, .markNotificationsAsSeen())
+    }
+    
+    func testGetAllNotificationsSuccess() async throws {
+        Given(mockInteractor, .getAllNotifications(page: 1, willReturn: notifications))
+        
+        viewModel = NotificationsInboxViewModel(
+            notificationsInteractor: mockInteractor,
+            analytics: NotificationsAnalyticsMock(),
+            router: NotificationsRouterMock(),
+            connectivity: Connectivity(),
+            deepLinkManager: NotificationsDeepLinkManagerMock()
+        )
+
+        await viewModel.loadNotifications()
+        
+        XCTAssertEqual(notifications.results?.count, viewModel.flatNotifications.count)
+    }
+    
+    func testGetAllNotificationsNoInternetError() async throws {
+        Given(mockInteractor, .getAllNotifications(page: 1, willThrow: URLError(.notConnectedToInternet)))
+        Given(mockConnectivity, .isInternetAvaliable(getter: false))
+        
+        viewModel = NotificationsInboxViewModel(
+            notificationsInteractor: mockInteractor,
+            analytics: NotificationsAnalyticsMock(),
+            router: NotificationsRouterMock(),
+            connectivity: mockConnectivity,
+            deepLinkManager: NotificationsDeepLinkManagerMock()
+        )
+
+        await viewModel.loadNotifications()
+        
+        XCTAssertEqual(viewModel.screenState, .noInternet)
+    }
+    
+    func testGetAllNotificationsUnknownError() async throws {
+        Given(mockInteractor, .getAllNotifications(page: 1, willThrow: NSError(domain: "error", code: -1, userInfo: nil)))
+        Given(mockConnectivity, .isInternetAvaliable(getter: true))
+        
+        viewModel = NotificationsInboxViewModel(
+            notificationsInteractor: mockInteractor,
+            analytics: NotificationsAnalyticsMock(),
+            router: NotificationsRouterMock(),
+            connectivity: mockConnectivity,
+            deepLinkManager: NotificationsDeepLinkManagerMock()
+        )
+
+        await viewModel.loadNotifications()
+        
+        XCTAssertEqual(viewModel.screenState, .serverError)
+    }
+    
+    func testIsDiscussionNotification() async throws {
+        await viewModel.loadNotifications()
+        
+        XCTAssertEqual(viewModel.flatNotifications[0].appName, "discussion")
+    }
+    
+    func testNotificationTypeAsCommentOnFollowedPost() async throws {
+        await viewModel.loadNotifications()
+        
+        XCTAssertEqual(viewModel.flatNotifications[0].notificationType, "comment_on_followed_post")
+    }
+    
+    func testNotificationTypeAsResponseOnFollowedPost() async throws {
+        await viewModel.loadNotifications()
+        
+        XCTAssertEqual(viewModel.flatNotifications[1].notificationType, "response_on_followed_post")
+    }
+    
+    func testNotificationTypeAsNewResponse() async throws {
+        await viewModel.loadNotifications()
+        
+        XCTAssertEqual(viewModel.flatNotifications[2].notificationType, "new_response")
+    }
+    
+    func testNotificationTypeAsNewComment() async throws {
+        await viewModel.loadNotifications()
+        
+        XCTAssertEqual(viewModel.flatNotifications[3].notificationType, "new_comment")
+    }
+}

--- a/Notifications/NotificationsTests/Presentation/NotificationsInboxViewModelTests.swift
+++ b/Notifications/NotificationsTests/Presentation/NotificationsInboxViewModelTests.swift
@@ -181,6 +181,10 @@ final class NotificationsInboxViewModelTests: XCTestCase {
         
         Verify(mockInteractor, 1, .markAllNotificationsAsRead())
         
+        XCTAssertNil(sut.flatNotifications[0].lastRead)
+        XCTAssertNil(sut.flatNotifications[1].lastRead)
+        XCTAssertNil(sut.flatNotifications[2].lastRead)
+        XCTAssertNil(sut.flatNotifications[3].lastRead)
         XCTAssertNotNil(sut.errorMessage)
         XCTAssertEqual(sut.errorMessage, CoreLocalization.Error.slowOrNoInternetConnection)
     }
@@ -195,6 +199,10 @@ final class NotificationsInboxViewModelTests: XCTestCase {
         
         Verify(mockInteractor, 1, .markAllNotificationsAsRead())
         
+        XCTAssertNil(sut.flatNotifications[0].lastRead)
+        XCTAssertNil(sut.flatNotifications[1].lastRead)
+        XCTAssertNil(sut.flatNotifications[2].lastRead)
+        XCTAssertNil(sut.flatNotifications[3].lastRead)
         XCTAssertNotNil(sut.errorMessage)
     }
     
@@ -208,17 +216,7 @@ final class NotificationsInboxViewModelTests: XCTestCase {
         Verify(mockInteractor, 1, .markNotificationsAsSeen())
     }
     
-    func testMarkNotificationsAsSeenNoInternetError() async throws {
-        let noInternetError = AFError.sessionInvalidated(error: URLError(.notConnectedToInternet))
-        
-        Given(mockInteractor, .markNotificationsAsSeen(willThrow: noInternetError))
-        
-        await sut.markNotificationsAsSeen()
-        
-        Verify(mockInteractor, 1, .markNotificationsAsSeen())
-    }
-    
-    func testMarkNotificationsAsSeenUnknownError() async throws {
+    func testMarkNotificationsAsSeenError() async throws {
         let unknown = AFError.sessionInvalidated(error: NSError(domain: "error", code: -1, userInfo: nil))
         
         Given(mockInteractor, .markNotificationsAsSeen(willThrow: unknown))
@@ -230,6 +228,8 @@ final class NotificationsInboxViewModelTests: XCTestCase {
     
     func testGetAllNotificationsSuccess() async throws {
         await sut.loadNotifications()
+        
+        Verify(mockInteractor, 1, .getAllNotifications(page: 1))
         
         XCTAssertEqual(notifications.results?.count, sut.flatNotifications.count)
         XCTAssertNil(sut.errorMessage)
@@ -243,6 +243,9 @@ final class NotificationsInboxViewModelTests: XCTestCase {
         
         await sut.loadNotifications()
         
+        Verify(mockInteractor, 1, .getAllNotifications(page: 1))
+        
+        XCTAssertEqual(sut.flatNotifications.count, .zero)
         XCTAssertEqual(sut.screenState, .noInternet)
     }
     
@@ -254,6 +257,9 @@ final class NotificationsInboxViewModelTests: XCTestCase {
         
         await sut.loadNotifications()
         
+        Verify(mockInteractor, 1, .getAllNotifications(page: 1))
+        
+        XCTAssertEqual(sut.flatNotifications.count, .zero)
         XCTAssertEqual(sut.screenState, .serverError)
     }
 }

--- a/OpenEdX.xcodeproj/xcshareddata/xcschemes/OpenEdXDev.xcscheme
+++ b/OpenEdX.xcodeproj/xcshareddata/xcschemes/OpenEdXDev.xcscheme
@@ -117,6 +117,16 @@
                ReferencedContainer = "container:Core/Core.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "022D04862976D7E100E0059B"
+               BuildableName = "NotificationsTests.xctest"
+               BlueprintName = "NotificationsTests"
+               ReferencedContainer = "container:Notifications/Notifications.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
[LEARNER-10560](https://2u-internal.atlassian.net/browse/LEARNER-10560): Notifications Module Unit Tests: Inbox Screen

Adds test cases to improve coverage and ensure stability for the Notification Inbox Screen. These tests validate expected behaviors and edge cases across different scenarios.