### PR TITLE
fix: app shows blacked out discussions during non-restricted period

### DIFF
--- a/Discussion/Discussion/Data/Model/Data_DiscussionInfo.swift
+++ b/Discussion/Discussion/Data/Model/Data_DiscussionInfo.swift
@@ -15,8 +15,15 @@ public struct DiscussionBlackout {
 
 public extension DataLayer {
     struct DiscussionInfo: Codable {
-        var discussionID: String?
+        var id: String?
+        var isPostingEnabled: Bool?
         var blackouts: [DiscussionBlackout]?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case isPostingEnabled = "is_posting_enabled"
+            case blackouts
+        }
     }
 
     struct DiscussionBlackout: Codable {
@@ -28,7 +35,8 @@ public extension DataLayer {
 public extension DataLayer.DiscussionInfo {
     var domain: DiscussionInfo {
         .init(
-            discussionID: discussionID,
+            id: id,
+            isPostingEnabled: isPostingEnabled,
             blackouts: blackouts?.compactMap { .init(start: $0.start, end: $0.end)  }
         )
     }

--- a/Discussion/Discussion/Data/Model/Data_DiscussionInfo.swift
+++ b/Discussion/Discussion/Data/Model/Data_DiscussionInfo.swift
@@ -8,36 +8,18 @@
 import Foundation
 import Core
 
-public struct DiscussionBlackout {
-    var start: String
-    var end: String
-}
-
 public extension DataLayer {
     struct DiscussionInfo: Codable {
-        var id: String?
         var isPostingEnabled: Bool?
-        var blackouts: [DiscussionBlackout]?
 
         enum CodingKeys: String, CodingKey {
-            case id
             case isPostingEnabled = "is_posting_enabled"
-            case blackouts
         }
-    }
-
-    struct DiscussionBlackout: Codable {
-        var start: String
-        var end: String
     }
 }
 
 public extension DataLayer.DiscussionInfo {
     var domain: DiscussionInfo {
-        .init(
-            id: id,
-            isPostingEnabled: isPostingEnabled,
-            blackouts: blackouts?.compactMap { .init(start: $0.start, end: $0.end)  }
-        )
+        .init(isPostingEnabled: isPostingEnabled)
     }
 }

--- a/Discussion/Discussion/Data/Network/DiscussionRepository.swift
+++ b/Discussion/Discussion/Data/Network/DiscussionRepository.swift
@@ -229,7 +229,7 @@ public class DiscussionRepository: DiscussionRepositoryProtocol {
 public class DiscussionRepositoryMock: DiscussionRepositoryProtocol {
 
     public func getCourseDiscussionInfo(courseID: String) async throws -> DiscussionInfo {
-        DiscussionInfo(id: nil, isPostingEnabled: true)
+        DiscussionInfo(isPostingEnabled: true)
     }
 
     public func getThread(threadID: String) async throws -> UserThread {

--- a/Discussion/Discussion/Data/Network/DiscussionRepository.swift
+++ b/Discussion/Discussion/Data/Network/DiscussionRepository.swift
@@ -229,7 +229,7 @@ public class DiscussionRepository: DiscussionRepositoryProtocol {
 public class DiscussionRepositoryMock: DiscussionRepositoryProtocol {
 
     public func getCourseDiscussionInfo(courseID: String) async throws -> DiscussionInfo {
-        DiscussionInfo(discussionID: nil, blackouts: [])
+        DiscussionInfo(id: nil, blackouts: [])
     }
 
     public func getThread(threadID: String) async throws -> UserThread {

--- a/Discussion/Discussion/Data/Network/DiscussionRepository.swift
+++ b/Discussion/Discussion/Data/Network/DiscussionRepository.swift
@@ -229,7 +229,7 @@ public class DiscussionRepository: DiscussionRepositoryProtocol {
 public class DiscussionRepositoryMock: DiscussionRepositoryProtocol {
 
     public func getCourseDiscussionInfo(courseID: String) async throws -> DiscussionInfo {
-        DiscussionInfo(id: nil, blackouts: [])
+        DiscussionInfo(id: nil, isPostingEnabled: true)
     }
 
     public func getThread(threadID: String) async throws -> UserThread {

--- a/Discussion/Discussion/Domain/Model/DiscussionInfo.swift
+++ b/Discussion/Discussion/Domain/Model/DiscussionInfo.swift
@@ -8,24 +8,15 @@
 import Foundation
 
 public struct DiscussionInfo {
-    public var discussionID: String?
+    public var id: String?
+    public var isPostingEnabled: Bool?
     public var blackouts: [DiscussionBlackout]?
 
     public func isBlackedOut() -> Bool {
-        guard let blackouts = blackouts else {
+        guard let isPostingEnabled else {
             return false
         }
-        var isBlackedOut = false
-        for blackout in blackouts {
-            let start = Date(iso8601: blackout.start)
-            let end = Date(iso8601: blackout.end)
 
-            if Date().isEarlierThanOrEqualTo(date: end) &&
-                Date().isLaterThanOrEqualTo(date: start) {
-                isBlackedOut = true
-            }
-        }
-
-        return isBlackedOut
+        return !isPostingEnabled
     }
 }

--- a/Discussion/Discussion/Domain/Model/DiscussionInfo.swift
+++ b/Discussion/Discussion/Domain/Model/DiscussionInfo.swift
@@ -8,15 +8,9 @@
 import Foundation
 
 public struct DiscussionInfo {
-    public var id: String?
     public var isPostingEnabled: Bool?
-    public var blackouts: [DiscussionBlackout]?
 
-    public func isBlackedOut() -> Bool {
-        guard let isPostingEnabled else {
-            return false
-        }
-
-        return !isPostingEnabled
+    public var isBlackedOut: Bool {
+        isPostingEnabled == false
     }
 }

--- a/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionTopicsViewModel.swift
+++ b/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionTopicsViewModel.swift
@@ -168,7 +168,7 @@ public class DiscussionTopicsViewModel: ObservableObject {
         isShowRefresh = !withProgress
         do {
             let discussionInfo = try await interactor.getCourseDiscussionInfo(courseID: courseID)
-            isBlackedOut = discussionInfo.isBlackedOut()
+            isBlackedOut = discussionInfo.isBlackedOut
              
             topics = try await interactor.getTopics(courseID: courseID)
             discussionTopics = generateTopics(topics: topics)

--- a/Discussion/Discussion/Presentation/Posts/PostsViewModel.swift
+++ b/Discussion/Discussion/Presentation/Posts/PostsViewModel.swift
@@ -172,7 +172,7 @@ public class PostsViewModel: ObservableObject {
         do {
             if let courseID, isBlackedOut == nil {
                 let discussionInfo = try await interactor.getCourseDiscussionInfo(courseID: courseID)
-                isBlackedOut = discussionInfo.isBlackedOut()
+                isBlackedOut = discussionInfo.isBlackedOut
             }
 
             if pageNumber == 1 {

--- a/Discussion/DiscussionTests/Presentation/DiscussionTopics/DiscussionTopicsViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/DiscussionTopics/DiscussionTopicsViewModelTests.swift
@@ -36,7 +36,7 @@ final class DiscussionTopicsViewModelTests: XCTestCase {
         ])
     ])
 
-    let discussionInfo = DiscussionInfo(id: "1", isPostingEnabled: true)
+    let discussionInfo = DiscussionInfo(isPostingEnabled: true)
 
     func testGetTopicsSuccess() async throws {
         let interactor = DiscussionInteractorProtocolMock()

--- a/Discussion/DiscussionTests/Presentation/DiscussionTopics/DiscussionTopicsViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/DiscussionTopics/DiscussionTopicsViewModelTests.swift
@@ -36,7 +36,7 @@ final class DiscussionTopicsViewModelTests: XCTestCase {
         ])
     ])
 
-    let discussionInfo = DiscussionInfo(discussionID: "1", blackouts: [])
+    let discussionInfo = DiscussionInfo(id: "1", isPostingEnabled: true)
 
     func testGetTopicsSuccess() async throws {
         let interactor = DiscussionInteractorProtocolMock()

--- a/Discussion/DiscussionTests/Presentation/Posts/PostViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/Posts/PostViewModelTests.swift
@@ -105,7 +105,7 @@ final class PostViewModelTests: XCTestCase {
                    numPages: 4),
     ])
 
-    let discussionInfo = DiscussionInfo(discussionID: "1", blackouts: [])
+    let discussionInfo = DiscussionInfo(id: "1", isPostingEnabled: true)
 
 
     func testGetThreadListSuccess() async throws {

--- a/Discussion/DiscussionTests/Presentation/Posts/PostViewModelTests.swift
+++ b/Discussion/DiscussionTests/Presentation/Posts/PostViewModelTests.swift
@@ -105,7 +105,7 @@ final class PostViewModelTests: XCTestCase {
                    numPages: 4),
     ])
 
-    let discussionInfo = DiscussionInfo(id: "1", isPostingEnabled: true)
+    let discussionInfo = DiscussionInfo(isPostingEnabled: true)
 
 
     func testGetThreadListSuccess() async throws {

--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
@@ -292,7 +292,7 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                         await self.showCourseDiscussion(
                             link: link,
                             courseDetails: courseDetails,
-                            isBlackedOut: discussionInfo.isBlackedOut()
+                            isBlackedOut: discussionInfo.isBlackedOut
                         )
                         self.router.dismissProgress()
                     }
@@ -513,14 +513,14 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                 topicID: topicId,
                 courseDetails: courseDetails,
                 topics: topics,
-                isBlackedOut: discussionInfo.isBlackedOut()
+                isBlackedOut: discussionInfo.isBlackedOut
             )
 
             if let threadId = notification.contentContext?.threadId, !threadId.isEmpty {
                 let userThread = try await discussionInteractor.getThread(threadID: threadId)
                 router.showThread(
                     userThread: userThread,
-                    isBlackedOut: discussionInfo.isBlackedOut(),
+                    isBlackedOut: discussionInfo.isBlackedOut,
                     responseID: notification.contentContext?.responseId
                 )
             }
@@ -532,7 +532,7 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                     courseID: courseDetails.courseID,
                     comment: comment,
                     parentComment: comment.toPost(username: storage.user?.username),
-                    isBlackedOut: discussionInfo.isBlackedOut()
+                    isBlackedOut: discussionInfo.isBlackedOut
                 )
             }
         } catch {


### PR DESCRIPTION
[LEARNER-10550](https://2u-internal.atlassian.net/browse/LEARNER-10550): edX iOS app is showing blacked out discussions for SC1x during non-restricted period

### Description

This PR fixes an issue where the edX iOS app for course **SC1x** was displaying blacked-out discussions, even though no blackout periods were currently active. The course content appeared correctly in the browser.

Based on confirmation from the backend team, the fix now relies on the `is_posting_enabled` flag from the discussion API. This flag is set to `false` only when discussion restrictions are active or a blackout period is currently ongoing, ensuring consistency with the browser's behavior.