### PR TITLE
feat: scroll to directed response from notifications screen

### DIFF
--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
@@ -21,7 +21,11 @@ public struct ThreadView: View {
     @State private var isShowProgress: Bool = true
     @State private var commentText: String = ""
     @State private var commentSize: CGFloat = .init(64)
-    
+
+    private enum Constants {
+        static let scrollingDelay: TimeInterval = 0.5
+    }
+
     public init(thread: UserThread,
                 viewModel: ThreadViewModel) {
         self.thread = thread
@@ -200,7 +204,7 @@ public struct ThreadView: View {
                         .onChange(of: viewModel.shouldScroll, perform: { shouldScroll in
                             guard shouldScroll else { return }
 
-                            doAfter {
+                            doAfter(Constants.scrollingDelay) {
                                 withAnimation {
                                     scroll.scrollTo(headingID, anchor: .top)
                                 }

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
@@ -17,6 +17,7 @@ public struct ThreadView: View {
     
     @ObservedObject private var viewModel: ThreadViewModel
     @Environment(\.colorScheme) var colorScheme
+    @State private var headingID = UUID()
     @State private var isShowProgress: Bool = true
     @State private var commentText: String = ""
     @State private var commentSize: CGFloat = .init(64)
@@ -100,7 +101,8 @@ public struct ThreadView: View {
                                         .padding(.leading, 24)
                                         .font(Theme.Fonts.titleMedium)
                                         .foregroundColor(Theme.Colors.textPrimary)
-                                        
+                                        .id(headingID)
+
                                         ForEach(Array(comments.comments.enumerated()), id: \.offset) { index, comment in
                                             CommentCell(
                                                 comment: comment,
@@ -192,6 +194,15 @@ public struct ThreadView: View {
                             withAnimation {
                                 if viewModel.postComments?.comments.isEmpty == false {
                                     scroll.scrollTo(0, anchor: .bottom)
+                                }
+                            }
+                        })
+                        .onChange(of: viewModel.shouldScroll, perform: { shouldScroll in
+                            guard shouldScroll else { return }
+
+                            doAfter {
+                                withAnimation {
+                                    scroll.scrollTo(headingID, anchor: .top)
                                 }
                             }
                         })

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadViewModel.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadViewModel.swift
@@ -12,7 +12,8 @@ import Core
 public class ThreadViewModel: BaseResponsesViewModel, ObservableObject {
     
     @Published var scrollTrigger: Bool = false
-    
+    @Published var shouldScroll = false
+
     internal let threadStateSubject = CurrentValueSubject<ThreadPostState?, Never>(nil)
     private var cancellable: AnyCancellable?
     private let coreStorage: CoreStorage
@@ -262,6 +263,7 @@ public class ThreadViewModel: BaseResponsesViewModel, ObservableObject {
         
         shouldHighlightResponse = true
         postComments?.comments = comments
+        shouldScroll = true
     }
     
     public func shouldHighlightResponse(_ index: Int) -> Bool {


### PR DESCRIPTION
[LEARNER-10568](https://2u-internal.atlassian.net/browse/LEARNER-10568): Add scroll to directed response from notifications screen

### Description
Ensures that tapping a discussion notification scrolls to the specific response within the thread.

### Demo
<video src="https://github.com/user-attachments/assets/cf56321d-9554-45f6-af1a-c9f5bbd9329c" />
