### PR TITLE
fix: correctly handle program deeplink in case of gallery dashboard mode

### DIFF
--- a/Dashboard/Dashboard/Presentation/Elements/DropDownMenu.swift
+++ b/Dashboard/Dashboard/Presentation/Elements/DropDownMenu.swift
@@ -9,7 +9,7 @@ import Theme
 import Core
 import SwiftUI
 
-enum MenuOption: String, CaseIterable {
+public enum MenuOption: String, CaseIterable {
     case courses
     case programs
     

--- a/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/PrimaryCourseDashboardView.swift
@@ -14,18 +14,18 @@ public struct PrimaryCourseDashboardView<ProgramView: View, TopBarButtons: View>
     @StateObject private var viewModel: PrimaryCourseDashboardViewModel
     private let router: DashboardRouter
     private let supportsElevatedTabBar: Bool
+    @Binding private var selectedMenu: MenuOption
     @ViewBuilder private let topBarButtons: () -> TopBarButtons
     @ViewBuilder let programView: ProgramView
     private let onRefresh: (() -> Void)?
     private var openDiscoveryPage: () -> Void
     private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     
-    @State private var selectedMenu: MenuOption = .courses
-    
     public init(
         viewModel: PrimaryCourseDashboardViewModel,
         router: DashboardRouter,
         supportsElevatedTabBar: Bool,
+        selectedMenu: Binding<MenuOption>,
         @ViewBuilder topBarButtons: @escaping () -> TopBarButtons,
         programView: ProgramView,
         onRefresh: (() -> Void)? = nil,
@@ -34,6 +34,7 @@ public struct PrimaryCourseDashboardView<ProgramView: View, TopBarButtons: View>
         self._viewModel = StateObject(wrappedValue: { viewModel }())
         self.router = router
         self.supportsElevatedTabBar = supportsElevatedTabBar
+        self._selectedMenu = selectedMenu
         self.topBarButtons = topBarButtons
         self.programView = programView
         self.onRefresh = onRefresh
@@ -411,6 +412,7 @@ struct PrimaryCourseDashboardView_Previews: PreviewProvider {
             viewModel: vm,
             router: DashboardRouterMock(),
             supportsElevatedTabBar: false,
+            selectedMenu: .constant(.courses),
             topBarButtons: {},
             programView: EmptyView(),
             openDiscoveryPage: {
@@ -423,6 +425,7 @@ struct PrimaryCourseDashboardView_Previews: PreviewProvider {
             viewModel: vm,
             router: DashboardRouterMock(),
             supportsElevatedTabBar: false,
+            selectedMenu: .constant(.courses),
             topBarButtons: {},
             programView: EmptyView(),
             openDiscoveryPage: {

--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
@@ -211,7 +211,7 @@ public class DeepLinkManager: NotificationsDeepLinkManager {
                 router.showProgram(pathID: pathID)
                 return
             }
-            router.showTabScreen(tab: .programs)
+            router.showPrograms()
         case .profile:
             router.showTabScreen(tab: .profile)
         case .userProfile:

--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
@@ -15,6 +15,7 @@ import Profile
 
 public protocol DeepLinkRouter: BaseRouter {
     func showTabScreen(tab: MainTab)
+    func showPrograms()
     func showDiscovery()
     func showDiscoveryDetails(
         link: DeepLink,
@@ -73,6 +74,12 @@ public extension DeepLinkRouter {
 extension Router: DeepLinkRouter {
 
     // MARK: - DeepLinkRouter
+
+    public func showPrograms() {
+        dismiss()
+        hostMainScreen?.rootView.viewModel.showPrograms()
+    }
+
     public func showDiscoveryDetails(
         link: DeepLink,
         pathID: String
@@ -211,7 +218,7 @@ extension Router: DeepLinkRouter {
         if hostProgramWebviewView?.rootView.pathID == pathID {
             return
         }
-        showTabScreen(tab: .programs)
+        showPrograms()
         showWebProgramDetails(
             pathID: pathID,
             viewType: .programDetail
@@ -355,6 +362,7 @@ extension Router: DeepLinkRouter {
 public class DeepLinkRouterMock: BaseRouterMock, DeepLinkRouter {
     public override init() {}
     public func showTabScreen(tab: MainTab) {}
+    public func showPrograms() {}
     public func showDiscovery() {}
     public func showDiscoveryDetails(
         link: DeepLink,

--- a/OpenEdX/View/MainScreenView.swift
+++ b/OpenEdX/View/MainScreenView.swift
@@ -96,6 +96,7 @@ struct MainScreenView: View {
                             viewModel: Container.shared.resolve(PrimaryCourseDashboardViewModel.self)!,
                             router: Container.shared.resolve(DashboardRouter.self)!,
                             supportsElevatedTabBar: supportsElevatedTabBar,
+                            selectedMenu: $viewModel.dashboardMenu,
                             topBarButtons: { notificationBell },
                             programView: ProgramWebviewView(
                                 viewModel: Container.shared.resolve(ProgramWebviewViewModel.self)!,

--- a/OpenEdX/View/MainScreenViewModel.swift
+++ b/OpenEdX/View/MainScreenViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Core
+import Dashboard
 import Notifications
 import Profile
 import Combine
@@ -23,6 +24,7 @@ final class MainScreenViewModel: ObservableObject {
     private var postLoginData: PostLoginData?
     
     @Published var selection: MainTab = .dashboard
+    @Published var dashboardMenu: Dashboard.MenuOption = .courses
     @Published var showRegisterBanner: Bool = false
     @Published var notificationBellIndicator: NotificationBellButton.Indicator = .none
 
@@ -56,6 +58,16 @@ final class MainScreenViewModel: ObservableObject {
     
     public func select(tab: MainTab) {
         selection = tab
+    }
+
+    func showPrograms() {
+        switch config.dashboard.type {
+        case .gallery:
+            select(tab: .dashboard)
+            dashboardMenu = .programs
+        case .list:
+            select(tab: .programs)
+        }
     }
 
     func trackMainDiscoveryTabClicked() {


### PR DESCRIPTION
[LEARNER-10582](https://2u-internal.atlassian.net/browse/LEARNER-10582): Notification Redirection  – Header Shows "Programs" but User Remains on Main Dashboard (Courses) Screen

### Description
This PR fixes an issue where tapping a push notification intended to open the **Programs** screen only updates the header title to **"Programs"** but does not navigate away from the **Main Dashboard (Courses)** screen.

**Steps to Reproduce (Fixed):**
- Receive a push notification related to a Program.
- Tap the notification.
- App correctly opens the Programs screen.