### PR TITLE
feat: non-consumable products to consumable products

### DIFF
--- a/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
+++ b/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
@@ -3206,17 +3206,10 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 		return __value
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(Parameter<String?>, Parameter<UpgradeMode>, Parameter<StoreProductInfo?>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<String?>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeCompletionHandler?>)
         case m_fetchProduct__sku_sku(Parameter<String>)
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -3237,8 +3230,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
 				return Matcher.ComparisonResult(results)
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -3247,14 +3238,12 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
             switch self {
             case let .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(p0, p1, p2, p3, p4, p5, p6, p7, p8): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue + p7.intValue + p8.intValue
             case let .m_fetchProduct__sku_sku(p0): return p0.intValue
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
             switch self {
             case .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion: return ".upgradeCourse(sku:mode:productInfo:pacing:courseID:lmsPrice:componentID:screen:completion:)"
             case .m_fetchProduct__sku_sku: return ".fetchProduct(sku:)"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -3288,7 +3277,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 
         public static func upgradeCourse(sku: Parameter<String?>, mode: Parameter<UpgradeMode>, productInfo: Parameter<StoreProductInfo?>, pacing: Parameter<String>, courseID: Parameter<String>, lmsPrice: Parameter<Double>, componentID: Parameter<String?>, screen: Parameter<CourseUpgradeScreen>, completion: Parameter<UpgradeCompletionHandler?>) -> Verify { return Verify(method: .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(`sku`, `mode`, `productInfo`, `pacing`, `courseID`, `lmsPrice`, `componentID`, `screen`, `completion`))}
         public static func fetchProduct(sku: Parameter<String>) -> Verify { return Verify(method: .m_fetchProduct__sku_sku(`sku`))}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -3300,9 +3288,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
         }
         public static func fetchProduct(sku: Parameter<String>, perform: @escaping (String) -> Void) -> Perform {
             return Perform(method: .m_fetchProduct__sku_sku(`sku`), performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 
@@ -3441,18 +3426,11 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 		perform?()
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<String?>, Parameter<NSDecimalNumber?>, Parameter<String?>, Parameter<Double?>, Parameter<CourseUpgradeScreen>)
         case m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(Parameter<CourseUpgradeHandler>, Parameter<UpgradeCompletionState>, Parameter<CourseUpgradeHelperDelegate?>)
         case m_showRestorePurchasesAlert
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -3475,8 +3453,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 				return Matcher.ComparisonResult(results)
 
             case (.m_showRestorePurchasesAlert, .m_showRestorePurchasesAlert): return .match
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -3486,7 +3462,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case let .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case .m_showRestorePurchasesAlert: return 0
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
@@ -3494,7 +3469,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen: return ".setData(courseID:pacing:blockID:localizedPrice:localizedCurrencyCode:lmsPrice:screen:)"
             case .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate: return ".handleCourseUpgrade(upgradeHadler:state:delegate:)"
             case .m_showRestorePurchasesAlert: return ".showRestorePurchasesAlert()"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -3516,7 +3490,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         public static func setData(courseID: Parameter<String>, pacing: Parameter<String>, blockID: Parameter<String?>, localizedPrice: Parameter<NSDecimalNumber?>, localizedCurrencyCode: Parameter<String?>, lmsPrice: Parameter<Double?>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `blockID`, `localizedPrice`, `localizedCurrencyCode`, `lmsPrice`, `screen`))}
         public static func handleCourseUpgrade(upgradeHadler: Parameter<CourseUpgradeHandler>, state: Parameter<UpgradeCompletionState>, delegate: Parameter<CourseUpgradeHelperDelegate?>) -> Verify { return Verify(method: .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(`upgradeHadler`, `state`, `delegate`))}
         public static func showRestorePurchasesAlert() -> Verify { return Verify(method: .m_showRestorePurchasesAlert)}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -3531,9 +3504,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         }
         public static func showRestorePurchasesAlert(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showRestorePurchasesAlert, performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 

--- a/Core/Core/Configuration/ServerConfig/IAPConfig.swift
+++ b/Core/Core/Configuration/ServerConfig/IAPConfig.swift
@@ -14,16 +14,19 @@ public class IAPConfig: NSObject {
         case disabledVersions = "ios_disabled_versions"
         case restoreEnabled = "restore_enabled"
         case bundelVersionString = "CFBundleShortVersionString"
+        case iosProductPrefix = "ios_product_prefix"
     }
 
     public var enabled: Bool = false
     private var disabledVersions: [String] = []
     public var restoreEnabled: Bool = false
+    public var iosProductPrefix: String
     
     init(dictionary: [String: Any]) {
         enabled = dictionary[Keys.enabled] as? Bool ?? false
         disabledVersions = dictionary[Keys.disabledVersions] as? [String] ?? []
         restoreEnabled = dictionary[Keys.restoreEnabled] as? Bool ?? false
+        iosProductPrefix = dictionary[Keys.iosProductPrefix] as? String ?? ""
         
         if let info = Bundle.main.infoDictionary,
            let currentVersion = info[Keys.bundelVersionString] as? String,

--- a/Core/Core/Configuration/ServerConfig/ServerConfig.swift
+++ b/Core/Core/Configuration/ServerConfig/ServerConfig.swift
@@ -47,7 +47,7 @@ public class ServerConfig: ServerConfigProtocol {
 #if DEBUG
 public class ServerConfigProtocolMock: ServerConfigProtocol {
     
-    let configString = "{\"iap_config\":{\"enabled\":true,\"experiment_enabled\":false,\"android_product_prefix\":\"mobile.android.usd\",\"allowed_users\":[\"all_users\"]},\"value_prop_enabled\":true,\"feedback_form_url\":\"https://bit.ly/edx-apps-feedback\",\"course_dates_calendar_sync\":{\"ios\":{\"enabled\":true,\"self_paced_enabled\":true,\"instructor_paced_enabled\":true,\"deep_links_enabled\":true},\"android\":{\"enabled\":true,\"self_paced_enabled\":true,\"instructor_paced_enabled\":true,\"deep_links_enabled\":true}}}"
+    let configString = "{\"iap_config\":{\"enabled\":true,\"experiment_enabled\":false,\"restore_enabled\":true,\"android_product_prefix\":\"mobile.android.usd\",\"ios_product_prefix\":\"mobile.ios.usd\",\"allowed_users\":[\"all_users\"]},\"value_prop_enabled\":true,\"feedback_form_url\":\"https://bit.ly/edx-apps-feedback\",\"disabled_countries\":[\"RU\"],\"course_dates_calendar_sync\":{\"ios\":{\"enabled\":true,\"self_paced_enabled\":true,\"instructor_paced_enabled\":true,\"deep_links_enabled\":true},\"android\":{\"enabled\":true,\"self_paced_enabled\":true,\"instructor_paced_enabled\":true,\"deep_links_enabled\":true}}}"
     
     var config: [String: Any] = [:]
     
@@ -63,7 +63,7 @@ public class ServerConfigProtocolMock: ServerConfigProtocol {
     
     public init() {
         valuePropEnabled = false
-        iapConfig = IAPConfig(dictionary: ["enabled": true, "restore_enabled": true])
+        iapConfig = IAPConfig(dictionary: ["enabled": true, "restore_enabled": true, "ios_product_prefix": "mobile.ios.usd"])
         initialize(serverConfig: configString)
     }
 }

--- a/Core/Core/Constants.swift
+++ b/Core/Core/Constants.swift
@@ -12,3 +12,8 @@ public struct Constants {
     public static let GrantTypePassword = "password"
     public static let GrantTypeRefreshToken = "refresh_token"
 }
+
+public struct IAPPriceRange {
+    public static let minimum = 1.0
+    public static let maximum = 1000.0
+}

--- a/Core/Core/Constants.swift
+++ b/Core/Core/Constants.swift
@@ -12,8 +12,3 @@ public struct Constants {
     public static let GrantTypePassword = "password"
     public static let GrantTypeRefreshToken = "refresh_token"
 }
-
-public struct IAPPriceRange {
-    public static let minimum = 1.0
-    public static let maximum = 1000.0
-}

--- a/Core/Core/CourseUpgrade/CourseUpgradeHandler.swift
+++ b/Core/Core/CourseUpgrade/CourseUpgradeHandler.swift
@@ -35,6 +35,23 @@ public enum UpgradeState {
     case error(UpgradeError)
 }
 
+public struct SKUBuilder {
+    private static let minimum = 1.0
+    private static let maximum = 1000.0
+
+    public static func buildSKU(prefix: String, price: Double?) -> String {
+        guard !prefix.isEmpty, let price = price else {
+            return ""
+        }
+        return prefix + String(Int(price))
+    }
+    
+    public static func isPriceValid(_ price: Double?) -> Bool {
+        guard let price = price else { return false }
+        return price >= minimum && price <= maximum
+    }
+}
+
 public class CourseUpgradeHandler: CourseUpgradeHandlerProtocol {
     static var ecommerceURL: String = ""
     

--- a/Core/Core/Data/Model/Data_Enrollments.swift
+++ b/Core/Core/Data/Model/Data_Enrollments.swift
@@ -193,20 +193,17 @@ public extension DataLayer {
     struct CourseMode: Codable {
         public let slug: Mode?
         public let sku: String?
-        public let iosSku: String?
         public let lmsPrice: Double?
 
         enum CodingKeys: String, CodingKey {
             case slug
             case sku
-            case iosSku = "ios_sku"
             case lmsPrice = "min_price"
         }
 
-        public init(slug: Mode?, sku: String?, iosSku: String?, lmsPrice: Double?) {
+        public init(slug: Mode?, sku: String?, lmsPrice: Double?) {
             self.slug = slug
             self.sku = sku
-            self.iosSku = iosSku
             self.lmsPrice = lmsPrice
         }
     }
@@ -279,7 +276,7 @@ public extension DataLayer {
 }
 
 public extension DataLayer.CourseEnrollments {
-    func domain(baseURL: String) -> ([CourseItem], DataLayer.ServerConfigs?) {
+    func domain(baseURL: String, iosProductPrefix: String) -> ([CourseItem], DataLayer.ServerConfigs?) {
         return (enrollments.results.map { result in
             let course = result.course
             
@@ -290,7 +287,7 @@ public extension DataLayer.CourseEnrollments {
             var lmsPrice: Double?
             
             for mode in result.courseModes where mode.slug == DataLayer.Mode.verified {
-                sku = mode.iosSku ?? ""
+                sku = iosProductPrefix.isEmpty ? "" : iosProductPrefix + String(Int(mode.lmsPrice ?? 0))
                 lmsPrice = mode.lmsPrice
             }
             

--- a/Core/Core/Data/Model/Data_Enrollments.swift
+++ b/Core/Core/Data/Model/Data_Enrollments.swift
@@ -287,7 +287,7 @@ public extension DataLayer.CourseEnrollments {
             var lmsPrice: Double?
             
             for mode in result.courseModes where mode.slug == DataLayer.Mode.verified {
-                sku = iosProductPrefix.isEmpty ? "" : iosProductPrefix + String(Int(mode.lmsPrice ?? 0))
+                sku = SKUBuilder.buildSKU(prefix: iosProductPrefix, price: mode.lmsPrice)
                 lmsPrice = mode.lmsPrice
             }
             

--- a/Core/Core/Data/Model/Data_PrimaryEnrollment.swift
+++ b/Core/Core/Data/Model/Data_PrimaryEnrollment.swift
@@ -73,9 +73,8 @@ public extension DataLayer {
             
             let startDate = Date(iso8601: start)
             let dynamicUpgradeDeadline = Date(iso8601: upgradeDeadline)
-            let isPriceValid = (lmsPrice ?? 0.0) >= IAPPriceRange.minimum && (lmsPrice ?? 0.0) <= IAPPriceRange.maximum
             return startDate.isInPast()
-            && isPriceValid
+            && SKUBuilder.isPriceValid(lmsPrice)
             && !dynamicUpgradeDeadline.isInPast()
         }
 
@@ -268,7 +267,7 @@ public extension DataLayer.PrimaryEnrollment {
             startDisplay: primary.course?.startDisplay.flatMap { Date(iso8601: $0) },
             startType: DisplayStartType(value: primary.course?.startType.rawValue),
             isUpgradeable: primary.isUpgradeable,
-            sku: iosProductPrefix.isEmpty ? "" : iosProductPrefix + String(Int(primary.lmsPrice ?? 0)),
+            sku: SKUBuilder.buildSKU(prefix: iosProductPrefix, price: primary.lmsPrice),
             lmsPrice: primary.lmsPrice,
             isSelfPaced: primary.course?.isSelfPaced ?? false,
             coursewareAccess: coursewareAccess

--- a/Core/Core/Data/Model/Data_PrimaryEnrollment.swift
+++ b/Core/Core/Data/Model/Data_PrimaryEnrollment.swift
@@ -60,10 +60,6 @@ public extension DataLayer {
             case courseAssignments = "course_assignments"
         }
         
-        public var sku: String? {
-            let mode = courseModes?.first { $0.slug == .verified }
-            return mode?.iosSku
-        }
         public var lmsPrice: Double? {
             let mode = courseModes?.first { $0.slug == .verified }
             return mode?.lmsPrice
@@ -77,9 +73,9 @@ public extension DataLayer {
             
             let startDate = Date(iso8601: start)
             let dynamicUpgradeDeadline = Date(iso8601: upgradeDeadline)
-            
+            let isPriceValid = (lmsPrice ?? 0.0) >= IAPPriceRange.minimum && (lmsPrice ?? 0.0) <= IAPPriceRange.maximum
             return startDate.isInPast()
-            && sku?.isEmpty == false
+            && isPriceValid
             && !dynamicUpgradeDeadline.isInPast()
         }
 
@@ -213,8 +209,12 @@ public extension DataLayer {
 
 public extension DataLayer.PrimaryEnrollment {
     
-    func domain(baseURL: String) -> (PrimaryEnrollment, DataLayer.ServerConfigs?) {
-        let primaryCourse = createPrimaryCourse(from: self.primary, baseURL: baseURL)
+    func domain(baseURL: String, iosProductPrefix: String) -> (PrimaryEnrollment, DataLayer.ServerConfigs?) {
+        let primaryCourse = createPrimaryCourse(
+            from: self.primary,
+            baseURL: baseURL,
+            iosProductPrefix: iosProductPrefix
+        )
         let courses = createCourseItems(from: self.enrollments, baseURL: baseURL)
         
         return (PrimaryEnrollment(
@@ -225,7 +225,11 @@ public extension DataLayer.PrimaryEnrollment {
         ), configs)
     }
     
-    private func createPrimaryCourse(from primary: DataLayer.ActiveEnrollment?, baseURL: String) -> PrimaryCourse? {
+    private func createPrimaryCourse(
+        from primary: DataLayer.ActiveEnrollment?,
+        baseURL: String,
+        iosProductPrefix: String
+    ) -> PrimaryCourse? {
         guard let primary = primary else { return nil }
         
         let futureAssignments = primary.courseAssignments?.futureAssignments ?? []
@@ -264,7 +268,7 @@ public extension DataLayer.PrimaryEnrollment {
             startDisplay: primary.course?.startDisplay.flatMap { Date(iso8601: $0) },
             startType: DisplayStartType(value: primary.course?.startType.rawValue),
             isUpgradeable: primary.isUpgradeable,
-            sku: primary.sku,
+            sku: iosProductPrefix.isEmpty ? "" : iosProductPrefix + String(Int(primary.lmsPrice ?? 0)),
             lmsPrice: primary.lmsPrice,
             isSelfPaced: primary.course?.isSelfPaced ?? false,
             coursewareAccess: coursewareAccess

--- a/Core/Core/Domain/Model/CourseItem.swift
+++ b/Core/Core/Domain/Model/CourseItem.swift
@@ -90,9 +90,8 @@ extension CourseItem {
         guard let upgradeDeadline = dynamicUpgradeDeadline, mode == .audit else {
             return false
         }
-        let isPriceValid = (lmsPrice ?? 0.0) >= IAPPriceRange.minimum && (lmsPrice ?? 0.0) <= IAPPriceRange.maximum
         return !upgradeDeadline.isInPast()
-        && isPriceValid
+        && SKUBuilder.isPriceValid(lmsPrice)
         && courseStart?.isInPast() ?? false
     }
 }

--- a/Core/Core/Domain/Model/CourseItem.swift
+++ b/Core/Core/Domain/Model/CourseItem.swift
@@ -90,8 +90,9 @@ extension CourseItem {
         guard let upgradeDeadline = dynamicUpgradeDeadline, mode == .audit else {
             return false
         }
+        let isPriceValid = (lmsPrice ?? 0.0) >= IAPPriceRange.minimum && (lmsPrice ?? 0.0) <= IAPPriceRange.maximum
         return !upgradeDeadline.isInPast()
-        && !sku.isEmpty
+        && isPriceValid
         && courseStart?.isInPast() ?? false
     }
 }

--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -29,17 +29,20 @@ public class CourseRepository: CourseRepositoryProtocol {
     private let coreStorage: CoreStorage
     private let config: ConfigProtocol
     private let persistence: CoursePersistenceProtocol
+    private let serverConfig: ServerConfigProtocol
     
     public init(
         api: API,
         coreStorage: CoreStorage,
         config: ConfigProtocol,
-        persistence: CoursePersistenceProtocol
+        persistence: CoursePersistenceProtocol,
+        serverConfig: ServerConfigProtocol
     ) {
         self.api = api
         self.coreStorage = coreStorage
         self.config = config
         self.persistence = persistence
+        self.serverConfig = serverConfig
     }
     
     public func getCourseBlocks(courseID: String) async throws -> CourseStructure {
@@ -175,7 +178,9 @@ public class CourseRepository: CourseRepositoryProtocol {
             org: course.org ?? "",
             isSelfPaced: course.isSelfPaced,
             isUpgradeable: course.isUpgradeable,
-            sku: course.courseSKU,
+            sku: serverConfig.iapConfig.iosProductPrefix.isEmpty
+            ? ""
+            : serverConfig.iapConfig.iosProductPrefix + String(Int(course.lmsPrice ?? 0)),
             coursewareAccessDetails: coursewareAccessDetails,
             courseProgress: course.courseProgress == nil ? nil : CourseProgress(
                 totalAssignmentsCount: course.courseProgress?.totalAssignmentsCount ?? 0,
@@ -468,7 +473,7 @@ And there are various ways of describing it-- call it oral poetry or
             org: course.org ?? "",
             isSelfPaced: course.isSelfPaced,
             isUpgradeable: course.isUpgradeable,
-            sku: course.courseSKU,
+            sku: "mobile.ios.usd" + String(course.lmsPrice ?? 0),
             coursewareAccessDetails: coursewareAccessDetails,
             courseProgress: course.courseProgress == nil ? nil : CourseProgress(
                 totalAssignmentsCount: course.courseProgress?.totalAssignmentsCount ?? 0,

--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -178,9 +178,7 @@ public class CourseRepository: CourseRepositoryProtocol {
             org: course.org ?? "",
             isSelfPaced: course.isSelfPaced,
             isUpgradeable: course.isUpgradeable,
-            sku: serverConfig.iapConfig.iosProductPrefix.isEmpty
-            ? ""
-            : serverConfig.iapConfig.iosProductPrefix + String(Int(course.lmsPrice ?? 0)),
+            sku: SKUBuilder.buildSKU(prefix: serverConfig.iapConfig.iosProductPrefix, price: course.lmsPrice),
             coursewareAccessDetails: coursewareAccessDetails,
             courseProgress: course.courseProgress == nil ? nil : CourseProgress(
                 totalAssignmentsCount: course.courseProgress?.totalAssignmentsCount ?? 0,
@@ -325,6 +323,8 @@ public class CourseRepository: CourseRepositoryProtocol {
 // swiftlint:disable all
 #if DEBUG
 class CourseRepositoryMock: CourseRepositoryProtocol {
+    private let serverConfig = ServerConfigProtocolMock()
+    
     func getCourseDatesOffline(courseID: String) async throws -> CourseDates {
         throw NoCachedDataError()
     }
@@ -473,7 +473,7 @@ And there are various ways of describing it-- call it oral poetry or
             org: course.org ?? "",
             isSelfPaced: course.isSelfPaced,
             isUpgradeable: course.isUpgradeable,
-            sku: "mobile.ios.usd" + String(course.lmsPrice ?? 0),
+            sku: SKUBuilder.buildSKU(prefix: serverConfig.iapConfig.iosProductPrefix, price: course.lmsPrice),
             coursewareAccessDetails: coursewareAccessDetails,
             courseProgress: course.courseProgress == nil ? nil : CourseProgress(
                 totalAssignmentsCount: course.courseProgress?.totalAssignmentsCount ?? 0,

--- a/Course/Course/Data/Model/Data_CourseOutlineResponse.swift
+++ b/Course/Course/Data/Model/Data_CourseOutlineResponse.swift
@@ -24,7 +24,6 @@ public extension DataLayer {
         public let courseModes: [CourseMode]?
         public let enrollmentDetails: EnrollmentDetail?
         public let courseStart: String?
-        public var courseSKU: String?
         public var lmsPrice: Double?
         public var courseMode: Mode?
         public let coursewareAccessDetails: CoursewareAccessDetails?
@@ -56,7 +55,6 @@ public extension DataLayer {
             courseModes: [CourseMode]? = nil,
             enrollmentDetails: EnrollmentDetail? = nil,
             courseStart: String? = nil,
-            courseSKU: String? = nil,
             courseMode: Mode? = .unknown,
             coursewareAccessDetails: CoursewareAccessDetails? = nil,
             courseProgress: CourseProgress?
@@ -78,7 +76,7 @@ public extension DataLayer {
             }
             self.courseProgress = courseProgress
             
-            populateCourseSKU()
+            populatelmsPrice()
         }
         
         public init(from decoder: Decoder) throws {
@@ -96,12 +94,11 @@ public extension DataLayer {
             courseStart = try? values.decode(String.self, forKey: .courseStart)
             coursewareAccessDetails = try? values.decode(CoursewareAccessDetails.self, forKey: .coursewareAccessDetails)
             courseProgress = try? values.decode(DataLayer.CourseProgress.self, forKey: .courseProgress)
-            populateCourseSKU()
+            populatelmsPrice()
         }
         
-        mutating func populateCourseSKU() {
+        mutating func populatelmsPrice() {
             for mode in courseModes ?? [] where mode.slug == .verified {
-                courseSKU = mode.iosSku ?? ""
                 lmsPrice = mode.lmsPrice
             }
         }
@@ -334,9 +331,10 @@ extension DataLayer.CourseStructure {
         
         let startDate = Date(iso8601: start)
         let dynamicUpgradeDeadline = Date(iso8601: upgradeDeadline)
+        let isPriceValid = (lmsPrice ?? 0.0) >= IAPPriceRange.minimum && (lmsPrice ?? 0.0) <= IAPPriceRange.maximum
         
         return startDate.isInPast()
-        && courseSKU?.isEmpty == false
+        && isPriceValid
         && !dynamicUpgradeDeadline.isInPast()
     }
 }

--- a/Course/Course/Data/Model/Data_CourseOutlineResponse.swift
+++ b/Course/Course/Data/Model/Data_CourseOutlineResponse.swift
@@ -76,7 +76,7 @@ public extension DataLayer {
             }
             self.courseProgress = courseProgress
             
-            populatelmsPrice()
+            populateLMSPrice()
         }
         
         public init(from decoder: Decoder) throws {
@@ -94,10 +94,10 @@ public extension DataLayer {
             courseStart = try? values.decode(String.self, forKey: .courseStart)
             coursewareAccessDetails = try? values.decode(CoursewareAccessDetails.self, forKey: .coursewareAccessDetails)
             courseProgress = try? values.decode(DataLayer.CourseProgress.self, forKey: .courseProgress)
-            populatelmsPrice()
+            populateLMSPrice()
         }
         
-        mutating func populatelmsPrice() {
+        mutating func populateLMSPrice() {
             for mode in courseModes ?? [] where mode.slug == .verified {
                 lmsPrice = mode.lmsPrice
             }
@@ -331,10 +331,9 @@ extension DataLayer.CourseStructure {
         
         let startDate = Date(iso8601: start)
         let dynamicUpgradeDeadline = Date(iso8601: upgradeDeadline)
-        let isPriceValid = (lmsPrice ?? 0.0) >= IAPPriceRange.minimum && (lmsPrice ?? 0.0) <= IAPPriceRange.maximum
         
         return startDate.isInPast()
-        && isPriceValid
+        && SKUBuilder.isPriceValid(lmsPrice)
         && !dynamicUpgradeDeadline.isInPast()
     }
 }

--- a/Course/CourseTests/CourseMock.generated.swift
+++ b/Course/CourseTests/CourseMock.generated.swift
@@ -3510,17 +3510,10 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 		return __value
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(Parameter<String?>, Parameter<UpgradeMode>, Parameter<StoreProductInfo?>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<String?>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeCompletionHandler?>)
         case m_fetchProduct__sku_sku(Parameter<String>)
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -3541,8 +3534,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
 				return Matcher.ComparisonResult(results)
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -3551,14 +3542,12 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
             switch self {
             case let .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(p0, p1, p2, p3, p4, p5, p6, p7, p8): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue + p7.intValue + p8.intValue
             case let .m_fetchProduct__sku_sku(p0): return p0.intValue
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
             switch self {
             case .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion: return ".upgradeCourse(sku:mode:productInfo:pacing:courseID:lmsPrice:componentID:screen:completion:)"
             case .m_fetchProduct__sku_sku: return ".fetchProduct(sku:)"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -3592,7 +3581,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 
         public static func upgradeCourse(sku: Parameter<String?>, mode: Parameter<UpgradeMode>, productInfo: Parameter<StoreProductInfo?>, pacing: Parameter<String>, courseID: Parameter<String>, lmsPrice: Parameter<Double>, componentID: Parameter<String?>, screen: Parameter<CourseUpgradeScreen>, completion: Parameter<UpgradeCompletionHandler?>) -> Verify { return Verify(method: .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(`sku`, `mode`, `productInfo`, `pacing`, `courseID`, `lmsPrice`, `componentID`, `screen`, `completion`))}
         public static func fetchProduct(sku: Parameter<String>) -> Verify { return Verify(method: .m_fetchProduct__sku_sku(`sku`))}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -3604,9 +3592,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
         }
         public static func fetchProduct(sku: Parameter<String>, perform: @escaping (String) -> Void) -> Perform {
             return Perform(method: .m_fetchProduct__sku_sku(`sku`), performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 
@@ -3745,18 +3730,11 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 		perform?()
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<String?>, Parameter<NSDecimalNumber?>, Parameter<String?>, Parameter<Double?>, Parameter<CourseUpgradeScreen>)
         case m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(Parameter<CourseUpgradeHandler>, Parameter<UpgradeCompletionState>, Parameter<CourseUpgradeHelperDelegate?>)
         case m_showRestorePurchasesAlert
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -3779,8 +3757,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 				return Matcher.ComparisonResult(results)
 
             case (.m_showRestorePurchasesAlert, .m_showRestorePurchasesAlert): return .match
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -3790,7 +3766,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case let .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case .m_showRestorePurchasesAlert: return 0
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
@@ -3798,7 +3773,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen: return ".setData(courseID:pacing:blockID:localizedPrice:localizedCurrencyCode:lmsPrice:screen:)"
             case .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate: return ".handleCourseUpgrade(upgradeHadler:state:delegate:)"
             case .m_showRestorePurchasesAlert: return ".showRestorePurchasesAlert()"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -3820,7 +3794,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         public static func setData(courseID: Parameter<String>, pacing: Parameter<String>, blockID: Parameter<String?>, localizedPrice: Parameter<NSDecimalNumber?>, localizedCurrencyCode: Parameter<String?>, lmsPrice: Parameter<Double?>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `blockID`, `localizedPrice`, `localizedCurrencyCode`, `lmsPrice`, `screen`))}
         public static func handleCourseUpgrade(upgradeHadler: Parameter<CourseUpgradeHandler>, state: Parameter<UpgradeCompletionState>, delegate: Parameter<CourseUpgradeHelperDelegate?>) -> Verify { return Verify(method: .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(`upgradeHadler`, `state`, `delegate`))}
         public static func showRestorePurchasesAlert() -> Verify { return Verify(method: .m_showRestorePurchasesAlert)}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -3835,9 +3808,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         }
         public static func showRestorePurchasesAlert(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showRestorePurchasesAlert, performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 

--- a/Dashboard/Dashboard/Data/DashboardRepository.swift
+++ b/Dashboard/Dashboard/Data/DashboardRepository.swift
@@ -78,8 +78,6 @@ public class DashboardRepository: DashboardRepositoryProtocol {
         persistence.savePrimaryEnrollment(enrollments: mappedResult.0)
         persistence.saveServerConfig(configs: mappedResult.1)
         
-        serverConfig.initialize(serverConfig: mappedResult.1?.config)
-        
         return mappedResult.0
     }
     

--- a/Dashboard/Dashboard/Data/DashboardRepository.swift
+++ b/Dashboard/Dashboard/Data/DashboardRepository.swift
@@ -43,14 +43,16 @@ public class DashboardRepository: DashboardRepositoryProtocol {
             DashboardEndpoint.getEnrollments(username: storage.user?.username ?? "", page: page)
         )
             .mapResponse(DataLayer.CourseEnrollments.self)
-            .domain(baseURL: config.baseURL.absoluteString)
+        serverConfig.initialize(serverConfig: result.configs?.config)
+        let mappedResult = result.domain(
+            baseURL: config.baseURL.absoluteString,
+            iosProductPrefix: serverConfig.iapConfig.iosProductPrefix
+        )
         
-        persistence.saveEnrollments(items: result.0)
-        persistence.saveServerConfig(configs: result.1)
+        persistence.saveEnrollments(items: mappedResult.0)
+        persistence.saveServerConfig(configs: mappedResult.1)
         
-        serverConfig.initialize(serverConfig: result.1?.config)
-        
-        return result.0
+        return mappedResult.0
     }
     
     public func getEnrollmentsOffline() async throws -> [CourseItem] {
@@ -67,13 +69,18 @@ public class DashboardRepository: DashboardRepositoryProtocol {
             )
         )
             .mapResponse(DataLayer.PrimaryEnrollment.self)
-            .domain(baseURL: config.baseURL.absoluteString)
-        persistence.savePrimaryEnrollment(enrollments: result.0)
-        persistence.saveServerConfig(configs: result.1)
+        serverConfig.initialize(serverConfig: result.configs?.config)
+        let mappedResult = result.domain(
+            baseURL: config.baseURL.absoluteString,
+            iosProductPrefix: serverConfig.iapConfig.iosProductPrefix
+        )
         
-        serverConfig.initialize(serverConfig: result.1?.config)
+        persistence.savePrimaryEnrollment(enrollments: mappedResult.0)
+        persistence.saveServerConfig(configs: mappedResult.1)
         
-        return result.0
+        serverConfig.initialize(serverConfig: mappedResult.1?.config)
+        
+        return mappedResult.0
     }
     
     public func getPrimaryEnrollmentOffline() async throws -> PrimaryEnrollment {
@@ -91,7 +98,7 @@ public class DashboardRepository: DashboardRepositoryProtocol {
             )
         )
             .mapResponse(DataLayer.PrimaryEnrollment.self)
-            .domain(baseURL: config.baseURL.absoluteString)
+            .domain(baseURL: config.baseURL.absoluteString, iosProductPrefix: "")
         return result.0
     }
 }
@@ -105,7 +112,7 @@ class DashboardRepositoryMock: DashboardRepositoryProtocol {
             let courseEnrollments = try
             DashboardRepository.CourseEnrollmentsJSON.data(using: .utf8)!
                 .mapResponse(DataLayer.CourseEnrollments.self)
-                .domain(baseURL: baseURL)
+                .domain(baseURL: baseURL, iosProductPrefix: "mobile.ios.usd")
             return courseEnrollments.0
         } catch {
             throw error

--- a/Dashboard/Dashboard/Data/Mock/CourseEnrollmentsMock.swift
+++ b/Dashboard/Dashboard/Data/Mock/CourseEnrollmentsMock.swift
@@ -70,14 +70,12 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "08D0410",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               },
               {
                 "slug": "verified",
                 "sku": "6D7CAF1",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               }
             ]
           },
@@ -130,8 +128,7 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "C748313",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               }
             ]
           },
@@ -184,14 +181,12 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "F84F145",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               },
               {
                 "slug": "verified",
                 "sku": "7B00BCC",
-                "android_sku": "mobile.android.7b00bcc",
-                "ios_sku": "mobile.ios.7b00bcc"
+                "android_sku": "mobile.android.7b00bcc"
               }
             ]
           },
@@ -244,8 +239,7 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "E059A8E",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               }
             ]
           },
@@ -298,14 +292,12 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "C08ED36",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               },
               {
                 "slug": "verified",
                 "sku": "10E91CB",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               }
             ]
           },
@@ -358,14 +350,12 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "22F61B0",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               },
               {
                 "slug": "verified",
                 "sku": "28D953F",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               }
             ]
           },
@@ -418,14 +408,12 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "4FACA1A",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               },
               {
                 "slug": "verified",
                 "sku": "85B9FCB",
-                "android_sku": "mobile.android.85b9fcb",
-                "ios_sku": "mobile.ios.85b9fcb"
+                "android_sku": "mobile.android.85b9fcb"
               }
             ]
           },
@@ -478,14 +466,12 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "4273238",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               },
               {
                 "slug": "verified",
                 "sku": "403F90D",
-                "android_sku": "mobile.android.403f90d",
-                "ios_sku": "mobile.ios.403f90d"
+                "android_sku": "mobile.android.403f90d"
               }
             ]
           },
@@ -538,14 +524,12 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "A962046",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               },
               {
                 "slug": "verified",
                 "sku": "AD41871",
-                "android_sku": "mobile.android.ad41871",
-                "ios_sku": "mobile.ios.ad41871"
+                "android_sku": "mobile.android.ad41871"
               }
             ]
           },
@@ -598,8 +582,7 @@ extension DashboardRepository {
               {
                 "slug": "audit",
                 "sku": "99D8FF6",
-                "android_sku": null,
-                "ios_sku": null
+                "android_sku": null
               }
             ]
           }

--- a/Dashboard/DashboardTests/DashboardMock.generated.swift
+++ b/Dashboard/DashboardTests/DashboardMock.generated.swift
@@ -2026,17 +2026,10 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 		return __value
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(Parameter<String?>, Parameter<UpgradeMode>, Parameter<StoreProductInfo?>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<String?>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeCompletionHandler?>)
         case m_fetchProduct__sku_sku(Parameter<String>)
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2057,8 +2050,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
 				return Matcher.ComparisonResult(results)
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2067,14 +2058,12 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
             switch self {
             case let .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(p0, p1, p2, p3, p4, p5, p6, p7, p8): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue + p7.intValue + p8.intValue
             case let .m_fetchProduct__sku_sku(p0): return p0.intValue
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
             switch self {
             case .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion: return ".upgradeCourse(sku:mode:productInfo:pacing:courseID:lmsPrice:componentID:screen:completion:)"
             case .m_fetchProduct__sku_sku: return ".fetchProduct(sku:)"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2108,7 +2097,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 
         public static func upgradeCourse(sku: Parameter<String?>, mode: Parameter<UpgradeMode>, productInfo: Parameter<StoreProductInfo?>, pacing: Parameter<String>, courseID: Parameter<String>, lmsPrice: Parameter<Double>, componentID: Parameter<String?>, screen: Parameter<CourseUpgradeScreen>, completion: Parameter<UpgradeCompletionHandler?>) -> Verify { return Verify(method: .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(`sku`, `mode`, `productInfo`, `pacing`, `courseID`, `lmsPrice`, `componentID`, `screen`, `completion`))}
         public static func fetchProduct(sku: Parameter<String>) -> Verify { return Verify(method: .m_fetchProduct__sku_sku(`sku`))}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2120,9 +2108,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
         }
         public static func fetchProduct(sku: Parameter<String>, perform: @escaping (String) -> Void) -> Perform {
             return Perform(method: .m_fetchProduct__sku_sku(`sku`), performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 
@@ -2261,18 +2246,11 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 		perform?()
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<String?>, Parameter<NSDecimalNumber?>, Parameter<String?>, Parameter<Double?>, Parameter<CourseUpgradeScreen>)
         case m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(Parameter<CourseUpgradeHandler>, Parameter<UpgradeCompletionState>, Parameter<CourseUpgradeHelperDelegate?>)
         case m_showRestorePurchasesAlert
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2295,8 +2273,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 				return Matcher.ComparisonResult(results)
 
             case (.m_showRestorePurchasesAlert, .m_showRestorePurchasesAlert): return .match
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2306,7 +2282,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case let .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case .m_showRestorePurchasesAlert: return 0
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
@@ -2314,7 +2289,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen: return ".setData(courseID:pacing:blockID:localizedPrice:localizedCurrencyCode:lmsPrice:screen:)"
             case .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate: return ".handleCourseUpgrade(upgradeHadler:state:delegate:)"
             case .m_showRestorePurchasesAlert: return ".showRestorePurchasesAlert()"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2336,7 +2310,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         public static func setData(courseID: Parameter<String>, pacing: Parameter<String>, blockID: Parameter<String?>, localizedPrice: Parameter<NSDecimalNumber?>, localizedCurrencyCode: Parameter<String?>, lmsPrice: Parameter<Double?>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `blockID`, `localizedPrice`, `localizedCurrencyCode`, `lmsPrice`, `screen`))}
         public static func handleCourseUpgrade(upgradeHadler: Parameter<CourseUpgradeHandler>, state: Parameter<UpgradeCompletionState>, delegate: Parameter<CourseUpgradeHelperDelegate?>) -> Verify { return Verify(method: .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(`upgradeHadler`, `state`, `delegate`))}
         public static func showRestorePurchasesAlert() -> Verify { return Verify(method: .m_showRestorePurchasesAlert)}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2351,9 +2324,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         }
         public static func showRestorePurchasesAlert(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showRestorePurchasesAlert, performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 

--- a/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
+++ b/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
@@ -2026,17 +2026,10 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 		return __value
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(Parameter<String?>, Parameter<UpgradeMode>, Parameter<StoreProductInfo?>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<String?>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeCompletionHandler?>)
         case m_fetchProduct__sku_sku(Parameter<String>)
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2057,8 +2050,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
 				return Matcher.ComparisonResult(results)
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2067,14 +2058,12 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
             switch self {
             case let .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(p0, p1, p2, p3, p4, p5, p6, p7, p8): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue + p7.intValue + p8.intValue
             case let .m_fetchProduct__sku_sku(p0): return p0.intValue
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
             switch self {
             case .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion: return ".upgradeCourse(sku:mode:productInfo:pacing:courseID:lmsPrice:componentID:screen:completion:)"
             case .m_fetchProduct__sku_sku: return ".fetchProduct(sku:)"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2108,7 +2097,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 
         public static func upgradeCourse(sku: Parameter<String?>, mode: Parameter<UpgradeMode>, productInfo: Parameter<StoreProductInfo?>, pacing: Parameter<String>, courseID: Parameter<String>, lmsPrice: Parameter<Double>, componentID: Parameter<String?>, screen: Parameter<CourseUpgradeScreen>, completion: Parameter<UpgradeCompletionHandler?>) -> Verify { return Verify(method: .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(`sku`, `mode`, `productInfo`, `pacing`, `courseID`, `lmsPrice`, `componentID`, `screen`, `completion`))}
         public static func fetchProduct(sku: Parameter<String>) -> Verify { return Verify(method: .m_fetchProduct__sku_sku(`sku`))}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2120,9 +2108,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
         }
         public static func fetchProduct(sku: Parameter<String>, perform: @escaping (String) -> Void) -> Perform {
             return Perform(method: .m_fetchProduct__sku_sku(`sku`), performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 
@@ -2261,18 +2246,11 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 		perform?()
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<String?>, Parameter<NSDecimalNumber?>, Parameter<String?>, Parameter<Double?>, Parameter<CourseUpgradeScreen>)
         case m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(Parameter<CourseUpgradeHandler>, Parameter<UpgradeCompletionState>, Parameter<CourseUpgradeHelperDelegate?>)
         case m_showRestorePurchasesAlert
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2295,8 +2273,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 				return Matcher.ComparisonResult(results)
 
             case (.m_showRestorePurchasesAlert, .m_showRestorePurchasesAlert): return .match
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2306,7 +2282,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case let .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case .m_showRestorePurchasesAlert: return 0
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
@@ -2314,7 +2289,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen: return ".setData(courseID:pacing:blockID:localizedPrice:localizedCurrencyCode:lmsPrice:screen:)"
             case .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate: return ".handleCourseUpgrade(upgradeHadler:state:delegate:)"
             case .m_showRestorePurchasesAlert: return ".showRestorePurchasesAlert()"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2336,7 +2310,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         public static func setData(courseID: Parameter<String>, pacing: Parameter<String>, blockID: Parameter<String?>, localizedPrice: Parameter<NSDecimalNumber?>, localizedCurrencyCode: Parameter<String?>, lmsPrice: Parameter<Double?>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `blockID`, `localizedPrice`, `localizedCurrencyCode`, `lmsPrice`, `screen`))}
         public static func handleCourseUpgrade(upgradeHadler: Parameter<CourseUpgradeHandler>, state: Parameter<UpgradeCompletionState>, delegate: Parameter<CourseUpgradeHelperDelegate?>) -> Verify { return Verify(method: .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(`upgradeHadler`, `state`, `delegate`))}
         public static func showRestorePurchasesAlert() -> Verify { return Verify(method: .m_showRestorePurchasesAlert)}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2351,9 +2324,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         }
         public static func showRestorePurchasesAlert(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showRestorePurchasesAlert, performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 

--- a/Discussion/DiscussionTests/DiscussionMock.generated.swift
+++ b/Discussion/DiscussionTests/DiscussionMock.generated.swift
@@ -2026,17 +2026,10 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 		return __value
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(Parameter<String?>, Parameter<UpgradeMode>, Parameter<StoreProductInfo?>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<String?>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeCompletionHandler?>)
         case m_fetchProduct__sku_sku(Parameter<String>)
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2057,8 +2050,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
 				return Matcher.ComparisonResult(results)
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2067,14 +2058,12 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
             switch self {
             case let .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(p0, p1, p2, p3, p4, p5, p6, p7, p8): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue + p7.intValue + p8.intValue
             case let .m_fetchProduct__sku_sku(p0): return p0.intValue
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
             switch self {
             case .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion: return ".upgradeCourse(sku:mode:productInfo:pacing:courseID:lmsPrice:componentID:screen:completion:)"
             case .m_fetchProduct__sku_sku: return ".fetchProduct(sku:)"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2108,7 +2097,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 
         public static func upgradeCourse(sku: Parameter<String?>, mode: Parameter<UpgradeMode>, productInfo: Parameter<StoreProductInfo?>, pacing: Parameter<String>, courseID: Parameter<String>, lmsPrice: Parameter<Double>, componentID: Parameter<String?>, screen: Parameter<CourseUpgradeScreen>, completion: Parameter<UpgradeCompletionHandler?>) -> Verify { return Verify(method: .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(`sku`, `mode`, `productInfo`, `pacing`, `courseID`, `lmsPrice`, `componentID`, `screen`, `completion`))}
         public static func fetchProduct(sku: Parameter<String>) -> Verify { return Verify(method: .m_fetchProduct__sku_sku(`sku`))}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2120,9 +2108,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
         }
         public static func fetchProduct(sku: Parameter<String>, perform: @escaping (String) -> Void) -> Perform {
             return Perform(method: .m_fetchProduct__sku_sku(`sku`), performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 
@@ -2261,18 +2246,11 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 		perform?()
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<String?>, Parameter<NSDecimalNumber?>, Parameter<String?>, Parameter<Double?>, Parameter<CourseUpgradeScreen>)
         case m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(Parameter<CourseUpgradeHandler>, Parameter<UpgradeCompletionState>, Parameter<CourseUpgradeHelperDelegate?>)
         case m_showRestorePurchasesAlert
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2295,8 +2273,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 				return Matcher.ComparisonResult(results)
 
             case (.m_showRestorePurchasesAlert, .m_showRestorePurchasesAlert): return .match
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2306,7 +2282,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case let .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case .m_showRestorePurchasesAlert: return 0
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
@@ -2314,7 +2289,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen: return ".setData(courseID:pacing:blockID:localizedPrice:localizedCurrencyCode:lmsPrice:screen:)"
             case .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate: return ".handleCourseUpgrade(upgradeHadler:state:delegate:)"
             case .m_showRestorePurchasesAlert: return ".showRestorePurchasesAlert()"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2336,7 +2310,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         public static func setData(courseID: Parameter<String>, pacing: Parameter<String>, blockID: Parameter<String?>, localizedPrice: Parameter<NSDecimalNumber?>, localizedCurrencyCode: Parameter<String?>, lmsPrice: Parameter<Double?>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `blockID`, `localizedPrice`, `localizedCurrencyCode`, `lmsPrice`, `screen`))}
         public static func handleCourseUpgrade(upgradeHadler: Parameter<CourseUpgradeHandler>, state: Parameter<UpgradeCompletionState>, delegate: Parameter<CourseUpgradeHelperDelegate?>) -> Verify { return Verify(method: .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(`upgradeHadler`, `state`, `delegate`))}
         public static func showRestorePurchasesAlert() -> Verify { return Verify(method: .m_showRestorePurchasesAlert)}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2351,9 +2324,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         }
         public static func showRestorePurchasesAlert(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showRestorePurchasesAlert, performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 

--- a/Notifications/NotificationsTests/NotificationsMock.generated.swift
+++ b/Notifications/NotificationsTests/NotificationsMock.generated.swift
@@ -2026,17 +2026,10 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 		return __value
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(Parameter<String?>, Parameter<UpgradeMode>, Parameter<StoreProductInfo?>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<String?>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeCompletionHandler?>)
         case m_fetchProduct__sku_sku(Parameter<String>)
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2057,8 +2050,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
 				return Matcher.ComparisonResult(results)
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2067,14 +2058,12 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
             switch self {
             case let .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(p0, p1, p2, p3, p4, p5, p6, p7, p8): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue + p7.intValue + p8.intValue
             case let .m_fetchProduct__sku_sku(p0): return p0.intValue
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
             switch self {
             case .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion: return ".upgradeCourse(sku:mode:productInfo:pacing:courseID:lmsPrice:componentID:screen:completion:)"
             case .m_fetchProduct__sku_sku: return ".fetchProduct(sku:)"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2108,7 +2097,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 
         public static func upgradeCourse(sku: Parameter<String?>, mode: Parameter<UpgradeMode>, productInfo: Parameter<StoreProductInfo?>, pacing: Parameter<String>, courseID: Parameter<String>, lmsPrice: Parameter<Double>, componentID: Parameter<String?>, screen: Parameter<CourseUpgradeScreen>, completion: Parameter<UpgradeCompletionHandler?>) -> Verify { return Verify(method: .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(`sku`, `mode`, `productInfo`, `pacing`, `courseID`, `lmsPrice`, `componentID`, `screen`, `completion`))}
         public static func fetchProduct(sku: Parameter<String>) -> Verify { return Verify(method: .m_fetchProduct__sku_sku(`sku`))}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2120,9 +2108,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
         }
         public static func fetchProduct(sku: Parameter<String>, perform: @escaping (String) -> Void) -> Perform {
             return Perform(method: .m_fetchProduct__sku_sku(`sku`), performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 
@@ -2261,18 +2246,11 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 		perform?()
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<String?>, Parameter<NSDecimalNumber?>, Parameter<String?>, Parameter<Double?>, Parameter<CourseUpgradeScreen>)
         case m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(Parameter<CourseUpgradeHandler>, Parameter<UpgradeCompletionState>, Parameter<CourseUpgradeHelperDelegate?>)
         case m_showRestorePurchasesAlert
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2295,8 +2273,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 				return Matcher.ComparisonResult(results)
 
             case (.m_showRestorePurchasesAlert, .m_showRestorePurchasesAlert): return .match
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2306,7 +2282,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case let .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case .m_showRestorePurchasesAlert: return 0
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
@@ -2314,7 +2289,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen: return ".setData(courseID:pacing:blockID:localizedPrice:localizedCurrencyCode:lmsPrice:screen:)"
             case .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate: return ".handleCourseUpgrade(upgradeHadler:state:delegate:)"
             case .m_showRestorePurchasesAlert: return ".showRestorePurchasesAlert()"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2336,7 +2310,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         public static func setData(courseID: Parameter<String>, pacing: Parameter<String>, blockID: Parameter<String?>, localizedPrice: Parameter<NSDecimalNumber?>, localizedCurrencyCode: Parameter<String?>, lmsPrice: Parameter<Double?>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `blockID`, `localizedPrice`, `localizedCurrencyCode`, `lmsPrice`, `screen`))}
         public static func handleCourseUpgrade(upgradeHadler: Parameter<CourseUpgradeHandler>, state: Parameter<UpgradeCompletionState>, delegate: Parameter<CourseUpgradeHelperDelegate?>) -> Verify { return Verify(method: .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(`upgradeHadler`, `state`, `delegate`))}
         public static func showRestorePurchasesAlert() -> Verify { return Verify(method: .m_showRestorePurchasesAlert)}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2351,9 +2324,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         }
         public static func showRestorePurchasesAlert(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showRestorePurchasesAlert, performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -329,7 +329,8 @@ class ScreenAssembly: Assembly {
                 api: r.resolve(API.self)!,
                 coreStorage: r.resolve(CoreStorage.self)!,
                 config: r.resolve(ConfigProtocol.self)!,
-                persistence: r.resolve(CoursePersistenceProtocol.self)!
+                persistence: r.resolve(CoursePersistenceProtocol.self)!,
+                serverConfig: r.resolve(ServerConfigProtocol.self)!
             )
         }
         container.register(CourseInteractorProtocol.self) { r in

--- a/Profile/ProfileTests/ProfileMock.generated.swift
+++ b/Profile/ProfileTests/ProfileMock.generated.swift
@@ -2026,17 +2026,10 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 		return __value
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(Parameter<String?>, Parameter<UpgradeMode>, Parameter<StoreProductInfo?>, Parameter<String>, Parameter<String>, Parameter<Double>, Parameter<String?>, Parameter<CourseUpgradeScreen>, Parameter<UpgradeCompletionHandler?>)
         case m_fetchProduct__sku_sku(Parameter<String>)
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2057,8 +2050,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsSku, rhs: rhsSku, with: matcher), lhsSku, rhsSku, "sku"))
 				return Matcher.ComparisonResult(results)
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2067,14 +2058,12 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
             switch self {
             case let .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(p0, p1, p2, p3, p4, p5, p6, p7, p8): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue + p7.intValue + p8.intValue
             case let .m_fetchProduct__sku_sku(p0): return p0.intValue
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
             switch self {
             case .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion: return ".upgradeCourse(sku:mode:productInfo:pacing:courseID:lmsPrice:componentID:screen:completion:)"
             case .m_fetchProduct__sku_sku: return ".fetchProduct(sku:)"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2108,7 +2097,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
 
         public static func upgradeCourse(sku: Parameter<String?>, mode: Parameter<UpgradeMode>, productInfo: Parameter<StoreProductInfo?>, pacing: Parameter<String>, courseID: Parameter<String>, lmsPrice: Parameter<Double>, componentID: Parameter<String?>, screen: Parameter<CourseUpgradeScreen>, completion: Parameter<UpgradeCompletionHandler?>) -> Verify { return Verify(method: .m_upgradeCourse__sku_skumode_modeproductInfo_productInfopacing_pacingcourseID_courseIDlmsPrice_lmsPricecomponentID_componentIDscreen_screencompletion_completion(`sku`, `mode`, `productInfo`, `pacing`, `courseID`, `lmsPrice`, `componentID`, `screen`, `completion`))}
         public static func fetchProduct(sku: Parameter<String>) -> Verify { return Verify(method: .m_fetchProduct__sku_sku(`sku`))}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2120,9 +2108,6 @@ open class CourseUpgradeHandlerProtocolMock: CourseUpgradeHandlerProtocol, Mock 
         }
         public static func fetchProduct(sku: Parameter<String>, perform: @escaping (String) -> Void) -> Perform {
             return Perform(method: .m_fetchProduct__sku_sku(`sku`), performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 
@@ -2261,18 +2246,11 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 		perform?()
     }
 
-    open func removeLoader() {
-        addInvocation(.m_removeLoader)
-		let perform = methodPerformValue(.m_removeLoader) as? () -> Void
-		perform?()
-    }
-
 
     fileprivate enum MethodType {
         case m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(Parameter<String>, Parameter<String>, Parameter<String?>, Parameter<NSDecimalNumber?>, Parameter<String?>, Parameter<Double?>, Parameter<CourseUpgradeScreen>)
         case m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(Parameter<CourseUpgradeHandler>, Parameter<UpgradeCompletionState>, Parameter<CourseUpgradeHelperDelegate?>)
         case m_showRestorePurchasesAlert
-        case m_removeLoader
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
             switch (lhs, rhs) {
@@ -2295,8 +2273,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
 				return Matcher.ComparisonResult(results)
 
             case (.m_showRestorePurchasesAlert, .m_showRestorePurchasesAlert): return .match
-
-            case (.m_removeLoader, .m_removeLoader): return .match
             default: return .none
             }
         }
@@ -2306,7 +2282,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case let .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(p0, p1, p2, p3, p4, p5, p6): return p0.intValue + p1.intValue + p2.intValue + p3.intValue + p4.intValue + p5.intValue + p6.intValue
             case let .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case .m_showRestorePurchasesAlert: return 0
-            case .m_removeLoader: return 0
             }
         }
         func assertionName() -> String {
@@ -2314,7 +2289,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
             case .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen: return ".setData(courseID:pacing:blockID:localizedPrice:localizedCurrencyCode:lmsPrice:screen:)"
             case .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate: return ".handleCourseUpgrade(upgradeHadler:state:delegate:)"
             case .m_showRestorePurchasesAlert: return ".showRestorePurchasesAlert()"
-            case .m_removeLoader: return ".removeLoader()"
             }
         }
     }
@@ -2336,7 +2310,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         public static func setData(courseID: Parameter<String>, pacing: Parameter<String>, blockID: Parameter<String?>, localizedPrice: Parameter<NSDecimalNumber?>, localizedCurrencyCode: Parameter<String?>, lmsPrice: Parameter<Double?>, screen: Parameter<CourseUpgradeScreen>) -> Verify { return Verify(method: .m_setData__courseID_courseIDpacing_pacingblockID_blockIDlocalizedPrice_localizedPricelocalizedCurrencyCode_localizedCurrencyCodelmsPrice_lmsPricescreen_screen(`courseID`, `pacing`, `blockID`, `localizedPrice`, `localizedCurrencyCode`, `lmsPrice`, `screen`))}
         public static func handleCourseUpgrade(upgradeHadler: Parameter<CourseUpgradeHandler>, state: Parameter<UpgradeCompletionState>, delegate: Parameter<CourseUpgradeHelperDelegate?>) -> Verify { return Verify(method: .m_handleCourseUpgrade__upgradeHadler_upgradeHadlerstate_statedelegate_delegate(`upgradeHadler`, `state`, `delegate`))}
         public static func showRestorePurchasesAlert() -> Verify { return Verify(method: .m_showRestorePurchasesAlert)}
-        public static func removeLoader() -> Verify { return Verify(method: .m_removeLoader)}
     }
 
     public struct Perform {
@@ -2351,9 +2324,6 @@ open class CourseUpgradeHelperProtocolMock: CourseUpgradeHelperProtocol, Mock {
         }
         public static func showRestorePurchasesAlert(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_showRestorePurchasesAlert, performs: perform)
-        }
-        public static func removeLoader(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeLoader, performs: perform)
         }
     }
 


### PR DESCRIPTION
[LEARNER-10620](https://2u-internal.atlassian.net/browse/LEARNER-10620): Migrate iOS from non-consumable products to consumable products

As part of aligning our in-app purchase (IAP) strategy and ensuring consistency across platforms and with App Store best practices, we need to migrate the iOS implementation of IAP from non-consumable products to consumable products.