### PR TITLE
feat: add config based support for video urls blacklisting

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		942A98592D4CAF5200DD8BBC /* ScreenStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942A98582D4CAF5200DD8BBC /* ScreenStateView.swift */; };
 		942C4D522DC505F1002BA81C /* TrackSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942C4D512DC505F1002BA81C /* TrackSelectionView.swift */; };
 		942C4D542DC508B7002BA81C /* TrackCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942C4D532DC508B7002BA81C /* TrackCardView.swift */; };
+		9476DCF42E3B9C8800FEC095 /* VideoPlayerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9476DCF32E3B9C8800FEC095 /* VideoPlayerConfig.swift */; };
 		949094972DC8E2D800A341D4 /* TrackSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949094962DC8E2D100A341D4 /* TrackSelectionViewModel.swift */; };
 		949094992DC8E44C00A341D4 /* TrackCardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949094982DC8E44700A341D4 /* TrackCardInfo.swift */; };
 		9499F1262D41375B00558D59 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9499F1252D41375B00558D59 /* AppEnvironment.swift */; };
@@ -439,6 +440,7 @@
 		942A98582D4CAF5200DD8BBC /* ScreenStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenStateView.swift; sourceTree = "<group>"; };
 		942C4D512DC505F1002BA81C /* TrackSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionView.swift; sourceTree = "<group>"; };
 		942C4D532DC508B7002BA81C /* TrackCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackCardView.swift; sourceTree = "<group>"; };
+		9476DCF32E3B9C8800FEC095 /* VideoPlayerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerConfig.swift; sourceTree = "<group>"; };
 		949094962DC8E2D100A341D4 /* TrackSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionViewModel.swift; sourceTree = "<group>"; };
 		949094982DC8E44700A341D4 /* TrackCardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackCardInfo.swift; sourceTree = "<group>"; };
 		9499F1252D41375B00558D59 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
@@ -1130,6 +1132,7 @@
 				E0D586192B2FF74C009B4BA7 /* DiscoveryConfig.swift */,
 				14D912D82C2553C70077CCCE /* FullStoryConfig.swift */,
 				94D1FC4C2DA7F39F000A904F /* OptimizelyConfig.swift */,
+				9476DCF32E3B9C8800FEC095 /* VideoPlayerConfig.swift */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -1438,6 +1441,7 @@
 				BA981BCE2B8F5C49005707C2 /* Sequence+Extensions.swift in Sources */,
 				02C917F029CDA99E00DBB8BD /* Data_Enrollments.swift in Sources */,
 				062C69AA2C198323002BD311 /* UpgradeInfoSheetView.swift in Sources */,
+				9476DCF42E3B9C8800FEC095 /* VideoPlayerConfig.swift in Sources */,
 				024FCD0028EF1CD300232339 /* WebBrowser.swift in Sources */,
 				027BD3B52909475900392132 /* KeyboardStateObserver.swift in Sources */,
 				0283347D28D4D3DE00C828FC /* Data_Discovery.swift in Sources */,

--- a/Core/Core/Configuration/Config/Config.swift
+++ b/Core/Core/Configuration/Config/Config.swift
@@ -35,6 +35,7 @@ public protocol ConfigProtocol {
     var fullStory: FullStoryConfig { get }
     var pushNotificationsEnabled: Bool { get }
     var optimizely: OptimizelyConfig { get }
+    var videoPlayer: VideoPlayerConfig { get }
 }
 
 public enum TokenType: String {

--- a/Core/Core/Configuration/Config/VideoPlayerConfig.swift
+++ b/Core/Core/Configuration/Config/VideoPlayerConfig.swift
@@ -1,0 +1,32 @@
+//
+//  VideoPlayerConfig.swift
+//  Core
+//
+//  Created by Muhammad Tayyab Akram on 31/07/25.
+//
+
+import Foundation
+
+private enum VideoPlayerKey {
+    static let videoTranscriptEnabled = "VIDEO_TRANSCRIPT_ENABLED"
+    static let blacklistURLs = "BLACKLIST_URLS"
+}
+
+public final class VideoPlayerConfig: NSObject {
+    public var videoTranscriptEnabled: Bool = false
+    public var blacklistURLs: [String] = []
+
+    init(dictionary: [String: AnyObject]) {
+        super.init()
+        videoTranscriptEnabled = dictionary[VideoPlayerKey.videoTranscriptEnabled] as? Bool ?? false
+        blacklistURLs = dictionary[VideoPlayerKey.blacklistURLs] as? [String] ?? []
+    }
+}
+
+private let videoPlayerKey = "VIDEO_PLAYER"
+
+extension Config {
+    public var videoPlayer: VideoPlayerConfig {
+        VideoPlayerConfig(dictionary: self[videoPlayerKey] as? [String: AnyObject] ?? [:])
+    }
+}

--- a/Course/Course/Presentation/Unit/CourseUnitView.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitView.swift
@@ -186,7 +186,11 @@ public struct CourseUnitView: View {
                             }
                         }
                     } else {
-                        switch LessonType.from(block, streamingQuality: viewModel.streamingQuality) {
+                        switch LessonType.from(
+                            block,
+                            streamingQuality: viewModel.streamingQuality,
+                            config: viewModel.config
+                        ) {
                             // MARK: YouTube
                         case let .youtube(url, blockID):
                             if index == viewModel.index {

--- a/Course/Course/Presentation/Unit/CourseUnitViewModel.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitViewModel.swift
@@ -17,7 +17,11 @@ public enum LessonType: Equatable {
     case unknown(String)
     case discussion(String, String, String)
     
-    static func from(_ block: CourseBlock, streamingQuality: StreamingQuality) -> Self {
+    static func from(
+        _ block: CourseBlock,
+        streamingQuality: StreamingQuality,
+        config: ConfigProtocol
+    ) -> Self {
         let mandatoryInjections: [WebviewInjection] = [.colorInversionCss, .ajaxCallback, .readability, .accessibility]
         switch block.type {
         case .course, .chapter, .vertical, .sequential:
@@ -34,7 +38,8 @@ public enum LessonType: Equatable {
             return .discussion(block.topicId ?? "", block.id, block.displayName)
         case .video:
             if let encodedVideo = block.encodedVideo?.video(streamingQuality: streamingQuality),
-               let videoURL = encodedVideo.url {
+               let videoURL = encodedVideo.url,
+               !config.videoPlayer.blacklistURLs.contains(where: { videoURL.hasPrefix($0) }) {
                 if encodedVideo.type == .youtube {
                     return .youtube(youtubeVideoUrl: videoURL, blockID: block.id)
                 } else if encodedVideo.isVideoURL {

--- a/ci_scripts/ci_prepare_env.sh
+++ b/ci_scripts/ci_prepare_env.sh
@@ -35,7 +35,7 @@ install_xcode_cloud_brew_dependencies () {
 }
 
 setup_github_actions_environment() {
-    brew update && brew install xcodegen xcodesorg/made/xcodes git-lfs
+    brew update && brew install xcodegen git-lfs
     
     bundle config path vendor/bundle
     bundle install --jobs 4 --retry 3


### PR DESCRIPTION
[LEARNER-10625](https://2u-internal.atlassian.net/browse/LEARNER-10625): Unable to Download or Play Videos for Specific Course "Financial Statement Analysis: Company Forecasts and Valuations"

### Description
This PR fixes video playback/download failure by blacklisting unsupported URL hosts via config. Affected videos now show the "unavailable component" screen instead of failing silently.

### Preview
<img width="320" height="696" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-01 at 18 21 31" src="https://github.com/user-attachments/assets/15b86a41-8396-498c-a5a1-64f2eecd5ea3" />
