### PR TITLE
fix: remove pagination indicator for single whats new screen

### DIFF
--- a/WhatsNew/WhatsNew/Presentation/WhatsNewView.swift
+++ b/WhatsNew/WhatsNew/Presentation/WhatsNewView.swift
@@ -132,12 +132,14 @@ public struct WhatsNewView: View {
                     if isHorizontal {
                         Spacer()
                     }
-                    PageControl(numberOfPages: viewModel.newItems.count, currentPage: viewModel.index)
-                        .frame(height: isHorizontal ? 8 : nil)
-                        .allowsHitTesting(false)
-                        .padding(.top, isHorizontal ? 0 : 170)
-                        .padding(.bottom, 8)
-                        .accessibilityIdentifier("whatsnew_pagecontrol")
+                    if viewModel.newItems.count > 1 {
+                        PageControl(numberOfPages: viewModel.newItems.count, currentPage: viewModel.index)
+                            .frame(height: isHorizontal ? 8 : nil)
+                            .allowsHitTesting(false)
+                            .padding(.top, isHorizontal ? 0 : 170)
+                            .padding(.bottom, 8)
+                            .accessibilityIdentifier("whatsnew_pagecontrol")
+                    }
                 }
                 
             }.onChange(of: index) { ind in


### PR DESCRIPTION
Remove the page control if there is only a single What's New screen. The pagination control should appear only when there is more than one page.
This requirement came up while adding the What's New screen for [LEARNER-10706](https://2u-internal.atlassian.net/browse/LEARNER-10706): iOS - What's New screens for Push Notifications.


| **Before** | **After** |
|----------|----------|
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-05 at 20 22 16" src="https://github.com/user-attachments/assets/635a971a-3b0d-49dc-92dd-86a0a90ae0e9" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-06 at 19 13 18" src="https://github.com/user-attachments/assets/1c748f1a-76b1-4098-bf82-fca3a9b990ab" /> |





