### PR TITLE
fix: Add Loader on POST Actions in Discussions

### DIFF
--- a/Discussion/Discussion/Presentation/Comments/Base/BaseResponsesViewModel.swift
+++ b/Discussion/Discussion/Presentation/Comments/Base/BaseResponsesViewModel.swift
@@ -23,7 +23,7 @@ public class BaseResponsesViewModel {
     public var nextPage = 2
     public var totalPages = 1
     @Published public var itemsCount = 0
-    public var fetchInProgress = false
+    @Published public var fetchInProgress = false
     
     var errorMessage: String? {
         didSet {

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
@@ -218,6 +218,7 @@ public struct ResponsesView: View {
                     VStack(alignment: .center) {
                         ProgressBar(size: 40, lineWidth: 8)
                             .padding(.horizontal)
+                            .accessibilityIdentifier("progress_bar")
                     }.frame(maxWidth: .infinity,
                             maxHeight: .infinity)
                 }

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
@@ -18,7 +18,6 @@ public struct ResponsesView: View {
     private let parentComment: Post
     
     @ObservedObject private var viewModel: ResponsesViewModel
-    @State private var isShowProgress: Bool = true
 
     public init(
         commentID: String,
@@ -215,7 +214,15 @@ public struct ResponsesView: View {
                         }
                     }
                 }
+                if viewModel.isShowProgress {
+                    VStack(alignment: .center) {
+                        ProgressBar(size: 40, lineWidth: 8)
+                            .padding(.horizontal)
+                    }.frame(maxWidth: .infinity,
+                            maxHeight: .infinity)
+                }
             }
+            .disabled(viewModel.isShowProgress)
             .ignoresSafeArea(.all, edges: .horizontal)
             .hideNavigationBar(false)
             .navigationBarBackButtonHidden(true)

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
@@ -219,8 +219,7 @@ public struct ResponsesView: View {
                         ProgressBar(size: 40, lineWidth: 8)
                             .padding(.horizontal)
                             .accessibilityIdentifier("progress_bar")
-                    }.frame(maxWidth: .infinity,
-                            maxHeight: .infinity)
+                    }.frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
             .disabled(viewModel.isShowProgress)

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesViewModel.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesViewModel.swift
@@ -110,6 +110,7 @@ public class ResponsesViewModel: BaseResponsesViewModel, ObservableObject {
     @MainActor
     func getResponsesData(commentID: String, parentComment: Post, page: Int, refresh: Bool = false) async -> Bool {
         guard !fetchInProgress else { return false }
+        isShowProgress = true
         do {
             let (comments, pagination) = try await interactor
                 .getCommentResponses(commentID: commentID, page: page)
@@ -125,6 +126,7 @@ public class ResponsesViewModel: BaseResponsesViewModel, ObservableObject {
                 self.comments += comments
             }
             postComments = generateCommentsResponses(comments: self.comments, parentComment: parentPost)
+            isShowProgress = false
             return true
         } catch let error {
             if error.isInternetError {
@@ -132,6 +134,7 @@ public class ResponsesViewModel: BaseResponsesViewModel, ObservableObject {
             } else {
                 errorMessage = CoreLocalization.Error.unknownError
             }
+            isShowProgress = false
             return false
         }
     }

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
@@ -251,8 +251,7 @@ public struct ThreadView: View {
                         ProgressBar(size: 40, lineWidth: 8)
                             .padding(.horizontal)
                             .accessibilityIdentifier("progress_bar")
-                    }.frame(maxWidth: .infinity,
-                            maxHeight: .infinity)
+                    }.frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
             .disabled(viewModel.fetchInProgress)

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
@@ -18,7 +18,6 @@ public struct ThreadView: View {
     @ObservedObject private var viewModel: ThreadViewModel
     @Environment(\.colorScheme) var colorScheme
     @State private var headingID = UUID()
-    @State private var isShowProgress: Bool = true
     @State private var commentText: String = ""
     @State private var commentSize: CGFloat = .init(64)
 
@@ -247,7 +246,15 @@ public struct ThreadView: View {
                         }
                     }
                 }
+                if viewModel.fetchInProgress {
+                    VStack(alignment: .center) {
+                        ProgressBar(size: 40, lineWidth: 8)
+                            .padding(.horizontal)
+                    }.frame(maxWidth: .infinity,
+                            maxHeight: .infinity)
+                }
             }
+            .disabled(viewModel.fetchInProgress)
             .ignoresSafeArea(.all, edges: .horizontal)
             .hideNavigationBar(false)
             .navigationBarBackButtonHidden(true)
@@ -265,7 +272,7 @@ public struct ThreadView: View {
             }
             .onFirstAppear {
                 Task {
-                    await viewModel.getThreadData(thread: thread, page: 1)
+                    await viewModel.getThreadData(thread: thread, page: 1, onFirstAppear: true)
                 }
                 viewModel.trackDiscussionPostViewed(
                     courseID: thread.courseID,

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadView.swift
@@ -250,6 +250,7 @@ public struct ThreadView: View {
                     VStack(alignment: .center) {
                         ProgressBar(size: 40, lineWidth: 8)
                             .padding(.horizontal)
+                            .accessibilityIdentifier("progress_bar")
                     }.frame(maxWidth: .infinity,
                             maxHeight: .infinity)
                 }

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadViewModel.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadViewModel.swift
@@ -152,7 +152,11 @@ public class ThreadViewModel: BaseResponsesViewModel, ObservableObject {
     }
     
     @MainActor
-    public func getThreadData(thread: UserThread, page: Int, refresh: Bool = false, onFirstAppear: Bool = false) async -> Bool {
+    public func getThreadData(
+        thread: UserThread,
+        page: Int, refresh: Bool = false,
+        onFirstAppear: Bool = false
+    ) async -> Bool {
         guard !fetchInProgress else { return false }
         fetchInProgress = onFirstAppear
         do {

--- a/Discussion/Discussion/Presentation/Comments/Thread/ThreadViewModel.swift
+++ b/Discussion/Discussion/Presentation/Comments/Thread/ThreadViewModel.swift
@@ -111,12 +111,12 @@ public class ThreadViewModel: BaseResponsesViewModel, ObservableObject {
         rawBody: String,
         parentID: String?
     ) async {
-        isShowProgress = true
+        fetchInProgress = true
         do {
             let newComment = try await interactor.addCommentTo(threadID: threadID,
                                                                rawBody: rawBody,
                                                                parentID: parentID)
-            isShowProgress = false
+            fetchInProgress = false
             addPostSubject.send(newComment)
             trackResponseAdded(
                 courseID: courseID,
@@ -125,7 +125,7 @@ public class ThreadViewModel: BaseResponsesViewModel, ObservableObject {
                 author: newComment.authorName
             )
         } catch let error {
-            isShowProgress = false
+            fetchInProgress = false
             if error.isInternetError {
                 errorMessage = CoreLocalization.Error.slowOrNoInternetConnection
             } else {
@@ -152,9 +152,9 @@ public class ThreadViewModel: BaseResponsesViewModel, ObservableObject {
     }
     
     @MainActor
-    public func getThreadData(thread: UserThread, page: Int, refresh: Bool = false) async -> Bool {
+    public func getThreadData(thread: UserThread, page: Int, refresh: Bool = false, onFirstAppear: Bool = false) async -> Bool {
         guard !fetchInProgress else { return false }
-        fetchInProgress = true
+        fetchInProgress = onFirstAppear
         do {
             try await interactor.readBody(threadID: thread.id)
             switch thread.type {


### PR DESCRIPTION
[LEARNER-10663](https://2u-internal.atlassian.net/browse/LEARNER-10663): Add Loader on POST Actions in Discussions
 
**Acceptance Criteria:**
- Loader is shown during each POST action
- Button becomes disabled during request
- User receives clear success or failure feedback

Before | After | 
--- | --- | 
<video src="https://github.com/user-attachments/assets/165a3f4e-5e82-40f2-9d6e-b6811ee4f4de" /> | <video src="https://github.com/user-attachments/assets/ecee5d1a-57ec-4ba6-9103-198273214082" /> | 

