### PR TITLE
fix: Improve deeplinking for courses vs programs routing

### DIFF
--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
@@ -61,6 +61,7 @@ public protocol DeepLinkRouter: BaseRouter {
     func showProgram(
         pathID: String
     )
+    func showCourses()
     func showUserProfile(userProfile: UserProfile)
     func dismissPresentedViewController()
     func showProgress()
@@ -80,6 +81,11 @@ extension Router: DeepLinkRouter {
     public func showPrograms() {
         dismiss()
         hostMainScreen?.rootView.viewModel.showPrograms()
+    }
+    
+    public func showCourses() {
+        dismiss()
+        hostMainScreen?.rootView.viewModel.showCourses()
     }
 
     public func showDiscoveryDetails(
@@ -119,7 +125,7 @@ extension Router: DeepLinkRouter {
         let isCourseOpened = hostCourseContainerView?.rootView.courseID == courseDetails.courseID
 
         if !isCourseOpened {
-            showTabScreen(tab: .dashboard)
+            showCourses()
 
             if courseDetails.isEnrolled {
                 showCourseScreens(
@@ -365,6 +371,7 @@ public class DeepLinkRouterMock: BaseRouterMock, DeepLinkRouter {
     public override init() {}
     public func showTabScreen(tab: MainTab) {}
     public func showPrograms() {}
+    public func showCourses() {}
     public func showDiscovery() {}
     public func showDiscoveryDetails(
         link: DeepLink,

--- a/OpenEdX/View/MainScreenViewModel.swift
+++ b/OpenEdX/View/MainScreenViewModel.swift
@@ -69,6 +69,16 @@ final class MainScreenViewModel: ObservableObject {
             select(tab: .programs)
         }
     }
+    
+    func showCourses() {
+        switch config.dashboard.type {
+        case .gallery:
+            select(tab: .dashboard)
+            dashboardMenu = .courses
+        case .list:
+            select(tab: .dashboard)
+        }
+    }
 
     func trackMainDiscoveryTabClicked() {
         analytics.mainDiscoveryTabClicked()


### PR DESCRIPTION
[LEARNER-10681](https://2u-internal.atlassian.net/browse/LEARNER-10681): Improve deeplinking for courses vs programs routing

Acceptance Criteria:
Change switcher to Courses if the selected option is Programs on the switcher and a deeplink for Courses is activated.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/35c1dae4-57f5-4021-88fe-251d7469bfec) | ![After](https://github.com/user-attachments/assets/63fc4e87-215a-46ec-9a5c-bb1f7b28e474) |