### PR TITLE
fix: "Explore new programs" button in the program screen

### DIFF
--- a/Discovery/Discovery/Presentation/DiscoveryRouter.swift
+++ b/Discovery/Discovery/Presentation/DiscoveryRouter.swift
@@ -39,6 +39,8 @@ public protocol DiscoveryRouter: BaseRouter {
         pathID: String,
         viewType: ProgramViewType
     )
+    
+    func showTabScreen(tab: MainTab)
 }
 
 // Mark - For testing and SwiftUI preview
@@ -76,6 +78,8 @@ public class DiscoveryRouterMock: BaseRouterMock, DiscoveryRouter {
         pathID: String,
         viewType: ProgramViewType
     ) {}
+    
+    public func showTabScreen(tab: MainTab) {}
 }
 #endif
 // swiftlint:enable function_parameter_count

--- a/Discovery/Discovery/Presentation/WebPrograms/ProgramWebviewViewModel.swift
+++ b/Discovery/Discovery/Presentation/WebPrograms/ProgramWebviewViewModel.swift
@@ -191,8 +191,8 @@ extension ProgramWebviewViewModel: WebViewNavigationDelegate {
             guard let pathID = detailPathID(from: url) else { return false }
             router.showWebProgramDetails(pathID: pathID, viewType: .programDetail)
             
-        default:
-            break
+        case .courseProgram:
+            router.showTabScreen(tab: .discovery)
         }
         
         return true


### PR DESCRIPTION

[LEARNER-10776](https://2u-internal.atlassian.net/browse/LEARNER-10776)
Redirect to discover screen when the "Explore new programs" button in the program screen is tapped


https://github.com/user-attachments/assets/67288857-7095-46d3-81a9-f6653769774d

