### PR TITLE
fix: iOS_ UI refresh spinner fails to dismiss post page reload

### DIFF
--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
@@ -50,6 +50,7 @@ public struct ResponsesView: View {
                     VStack {
                         ZStack(alignment: .top) {
                             RefreshableScrollViewCompat(action: {
+                                viewModel.comments = []
                                 _ = await viewModel.getResponsesData(
                                     commentID: commentID,
                                     parentComment: parentComment,

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesView.swift
@@ -50,12 +50,12 @@ public struct ResponsesView: View {
                     VStack {
                         ZStack(alignment: .top) {
                             RefreshableScrollViewCompat(action: {
-                                viewModel.comments = []
                                 _ = await viewModel.getResponsesData(
                                     commentID: commentID,
                                     parentComment: parentComment,
                                     page: 1,
-                                    refresh: true
+                                    refresh: true,
+                                    showProgress: false
                                 )
                             }) {
                                 VStack {

--- a/Discussion/Discussion/Presentation/Comments/Responses/ResponsesViewModel.swift
+++ b/Discussion/Discussion/Presentation/Comments/Responses/ResponsesViewModel.swift
@@ -108,9 +108,16 @@ public class ResponsesViewModel: BaseResponsesViewModel, ObservableObject {
     }
     
     @MainActor
-    func getResponsesData(commentID: String, parentComment: Post, page: Int, refresh: Bool = false) async -> Bool {
+    func getResponsesData(commentID: String,
+                          parentComment: Post,
+                          page: Int,
+                          refresh: Bool = false,
+                          showProgress: Bool = true) async -> Bool {
         guard !fetchInProgress else { return false }
-        isShowProgress = true
+        isShowProgress = showProgress
+        defer {
+            isShowProgress = false
+        }
         do {
             let (comments, pagination) = try await interactor
                 .getCommentResponses(commentID: commentID, page: page)
@@ -126,7 +133,6 @@ public class ResponsesViewModel: BaseResponsesViewModel, ObservableObject {
                 self.comments += comments
             }
             postComments = generateCommentsResponses(comments: self.comments, parentComment: parentPost)
-            isShowProgress = false
             return true
         } catch let error {
             if error.isInternetError {
@@ -134,7 +140,6 @@ public class ResponsesViewModel: BaseResponsesViewModel, ObservableObject {
             } else {
                 errorMessage = CoreLocalization.Error.unknownError
             }
-            isShowProgress = false
             return false
         }
     }


### PR DESCRIPTION
[LEARNER-10786](https://2u-internal.atlassian.net/browse/LEARNER-10786)
- Dismiss refresh spinner on Comments screen.
- Show only one spinner on pull to refresh.